### PR TITLE
feat(context-menu): add context menu component (#7)

### DIFF
--- a/apps/docs/.vitepress/config.ts
+++ b/apps/docs/.vitepress/config.ts
@@ -87,6 +87,7 @@ export default defineConfig({
           { text: "Checkbox", link: "/components/checkbox" },
           { text: "Collapsible", link: "/components/collapsible" },
           { text: "Combobox", link: "/components/combobox" },
+          { text: "Context Menu", link: "/components/context-menu" },
           { text: "Dialog", link: "/components/dialog" },
           { text: "Drawer", link: "/components/drawer" },
           { text: "Dropdown Menu", link: "/components/dropdown-menu" },

--- a/apps/docs/.vitepress/theme/components/ThemeBuilder.vue
+++ b/apps/docs/.vitepress/theme/components/ThemeBuilder.vue
@@ -1457,6 +1457,27 @@ const totalModified = computed(() => TOKEN_GROUPS.reduce((sum, g) => sum + modif
               </hp-dropdown-menu>
             </div>
           </section>
+
+          <section class="tb-preview-section">
+            <h4 class="tb-preview-section-title">Menú contextual</h4>
+            <div class="tb-preview-demo tb-preview-demo--row">
+              <hp-context-menu class="tbp-context-menu">
+                <hp-context-menu-trigger class="tbp-context-menu-trigger">
+                  <div class="tbp-context-menu-area">🖱️ Clic derecho aquí</div>
+                </hp-context-menu-trigger>
+                <hp-context-menu-content class="tbp-context-menu-content">
+                  <hp-context-menu-label>Editar</hp-context-menu-label>
+                  <hp-context-menu-item value="cut">✂️ Cortar</hp-context-menu-item>
+                  <hp-context-menu-item value="copy">📋 Copiar</hp-context-menu-item>
+                  <hp-context-menu-item value="paste">📌 Pegar</hp-context-menu-item>
+                  <hp-context-menu-separator></hp-context-menu-separator>
+                  <hp-context-menu-label>Zona peligrosa</hp-context-menu-label>
+                  <hp-context-menu-item value="delete">🗑️ Eliminar</hp-context-menu-item>
+                  <hp-context-menu-item value="archive" disabled>📦 Archivar</hp-context-menu-item>
+                </hp-context-menu-content>
+              </hp-context-menu>
+            </div>
+          </section>
         </div>
       </div>
     </div>
@@ -2879,6 +2900,96 @@ hp-accordion-content.tbp-accordion-content[data-state="closed"] {
 }
 
 .tbp-dropdown-menu-content hp-dropdown-menu-label {
+  padding: var(--hp-space-1, 0.25rem) var(--hp-space-3, 0.75rem);
+  font-size: var(--hp-font-size-xs, 0.75rem);
+  font-weight: var(--hp-font-weight-semibold, 600);
+  color: var(--hp-text-secondary, #64748b);
+  user-select: none;
+}
+
+/* Context Menu */
+.tbp-context-menu {
+  position: relative;
+  display: block;
+}
+
+.tbp-context-menu-trigger {
+  display: block;
+}
+
+.tbp-context-menu-area {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem 2rem;
+  border: 2px dashed var(--hp-border, #e2e8f0);
+  border-radius: var(--hp-radius, 0.5rem);
+  cursor: context-menu;
+  user-select: none;
+  font-size: var(--hp-font-size-sm, 0.875rem);
+  color: var(--hp-text-secondary, #64748b);
+  transition:
+    border-color 0.15s ease,
+    background-color 0.15s ease;
+}
+
+.tbp-context-menu-area:hover {
+  border-color: var(--hp-accent, #3b82f6);
+  background: var(--hp-bg-muted, #f1f5f9);
+}
+
+hp-context-menu-trigger[data-state="open"] .tbp-context-menu-area {
+  border-color: var(--hp-accent, #3b82f6);
+  border-style: solid;
+  background: var(--hp-bg-subtle, #e2e8f0);
+}
+
+.tbp-context-menu-content {
+  position: absolute;
+  z-index: 50;
+  min-width: 12rem;
+  background: var(--hp-surface, #fff);
+  border: 1px solid var(--hp-border, #e2e8f0);
+  border-radius: var(--hp-radius, 0.5rem);
+  box-shadow: var(--hp-shadow-lg, 0 8px 32px rgb(0 0 0 / 0.12), 0 2px 8px rgb(0 0 0 / 0.08));
+  padding: var(--hp-space-1, 0.25rem) 0;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition:
+    opacity 0.15s ease,
+    visibility 0.15s ease;
+}
+
+.tbp-context-menu-content[data-state="open"] {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+}
+
+.tbp-context-menu-content hp-context-menu-item {
+  padding: var(--hp-space-2, 0.5rem) var(--hp-space-3, 0.75rem);
+  font-size: var(--hp-font-size-sm, 0.875rem);
+  color: var(--hp-text, #0f172a);
+  cursor: pointer;
+}
+
+.tbp-context-menu-content hp-context-menu-item:hover:not([aria-disabled="true"]) {
+  background: var(--hp-bg-muted, #f1f5f9);
+}
+
+.tbp-context-menu-content hp-context-menu-item[aria-disabled="true"] {
+  opacity: var(--hp-opacity-disabled, 0.5);
+  cursor: not-allowed;
+}
+
+.tbp-context-menu-content hp-context-menu-separator {
+  height: 1px;
+  margin: var(--hp-space-1, 0.25rem) 0;
+  background: var(--hp-border, #e2e8f0);
+}
+
+.tbp-context-menu-content hp-context-menu-label {
   padding: var(--hp-space-1, 0.25rem) var(--hp-space-3, 0.75rem);
   font-size: var(--hp-font-size-xs, 0.75rem);
   font-weight: var(--hp-font-weight-semibold, 600);

--- a/apps/docs/.vitepress/theme/index.ts
+++ b/apps/docs/.vitepress/theme/index.ts
@@ -9,6 +9,7 @@ import "@headless-primitives/button";
 import "@headless-primitives/checkbox";
 import "@headless-primitives/collapsible";
 import "@headless-primitives/combobox";
+import "@headless-primitives/context-menu";
 import "@headless-primitives/dialog";
 import "@headless-primitives/drawer";
 import "@headless-primitives/dropdown-menu";

--- a/apps/docs/components/context-menu.md
+++ b/apps/docs/components/context-menu.md
@@ -1,0 +1,447 @@
+# Context Menu
+
+<span class="hp-badge">Nuevo</span>
+
+El componente `hp-context-menu` es un primitivo que implementa el patron WAI-ARIA **Menu** activado por clic derecho (o Shift+F10), permitiendo crear menus contextuales accesibles posicionados en las coordenadas del cursor, con navegacion por teclado completa, separadores y labels de grupo.
+
+## Instalacion
+
+::: code-group
+
+```bash [pnpm]
+pnpm add @headless-primitives/context-menu
+```
+
+```bash [npm]
+npm install @headless-primitives/context-menu
+```
+
+```bash [yarn]
+yarn add @headless-primitives/context-menu
+```
+
+```bash [bun]
+bun add @headless-primitives/context-menu
+```
+
+:::
+
+## Demostracion
+
+### Sin estilos (solo base.css)
+
+Asi se ve `hp-context-menu` usando unicamente `@headless-primitives/utils/base.css`. La navegacion por teclado, la visibilidad del popup y los roles ARIA funcionan completamente.
+
+<div class="hp-demo-card">
+  <hp-context-menu>
+    <hp-context-menu-trigger>Haz clic derecho aqui</hp-context-menu-trigger>
+    <hp-context-menu-content>
+      <hp-context-menu-item value="copy">Copy</hp-context-menu-item>
+      <hp-context-menu-item value="paste">Paste</hp-context-menu-item>
+      <hp-context-menu-item value="delete">Delete</hp-context-menu-item>
+    </hp-context-menu-content>
+  </hp-context-menu>
+</div>
+
+### Con estilos personalizados
+
+<div class="hp-demo-card">
+  <hp-context-menu class="demo-cm">
+    <hp-context-menu-trigger class="demo-cm-trigger">
+      <div class="demo-cm-area">🖱️ Haz clic derecho aqui (o Shift+F10)</div>
+    </hp-context-menu-trigger>
+    <hp-context-menu-content class="demo-cm-content">
+      <hp-context-menu-label>Edit</hp-context-menu-label>
+      <hp-context-menu-item value="cut">✂️ Cut</hp-context-menu-item>
+      <hp-context-menu-item value="copy">📋 Copy</hp-context-menu-item>
+      <hp-context-menu-item value="paste">📌 Paste</hp-context-menu-item>
+      <hp-context-menu-separator></hp-context-menu-separator>
+      <hp-context-menu-label>Danger Zone</hp-context-menu-label>
+      <hp-context-menu-item value="delete">🗑️ Delete</hp-context-menu-item>
+      <hp-context-menu-item value="archive" disabled>📦 Archive (deshabilitado)</hp-context-menu-item>
+    </hp-context-menu-content>
+  </hp-context-menu>
+</div>
+
+<style>
+hp-context-menu,
+hp-context-menu-trigger,
+hp-context-menu-content,
+hp-context-menu-item,
+hp-context-menu-separator,
+hp-context-menu-label {
+  display: block;
+}
+.demo-cm {
+  position: relative;
+  display: block;
+}
+.demo-cm-trigger {
+  display: block;
+}
+.demo-cm-area {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  min-height: 100px;
+  color: var(--vp-c-text-1);
+  background: var(--vp-c-bg-soft);
+  border: 2px dashed var(--vp-c-divider);
+  border-radius: 8px;
+  cursor: context-menu;
+  user-select: none;
+  transition: all 0.15s ease;
+}
+.demo-cm-area:hover {
+  border-color: var(--vp-c-brand-1);
+  background: var(--vp-c-bg);
+}
+hp-context-menu-trigger[data-state="open"] .demo-cm-area {
+  border-color: var(--vp-c-brand-1);
+  border-style: solid;
+  background: var(--vp-c-bg);
+}
+.demo-cm-content {
+  position: absolute;
+  z-index: 50;
+  min-width: 12rem;
+  overflow-y: auto;
+  background: var(--vp-c-bg);
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  padding: 0.25rem 0;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity 0.15s ease, visibility 0.15s ease;
+}
+.demo-cm-content[data-state="open"] {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+}
+hp-context-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  color: var(--vp-c-text-1);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  user-select: none;
+  text-align: left;
+  transition: background 0.1s ease;
+  min-height: 2rem;
+}
+hp-context-menu-item:hover:not([aria-disabled="true"]) {
+  background: var(--vp-c-bg-soft);
+}
+hp-context-menu-item[aria-disabled="true"] {
+  opacity: 0.5;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+hp-context-menu-separator {
+  height: 1px;
+  margin: 0.25rem 0;
+  background: var(--vp-c-divider);
+}
+hp-context-menu-label {
+  padding: 0.375rem 0.75rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--vp-c-text-2);
+  user-select: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .demo-cm-area,
+  .demo-cm-content,
+  hp-context-menu-item {
+    transition: none;
+  }
+}
+</style>
+
+## Anatomia
+
+```html
+<hp-context-menu>
+  <hp-context-menu-trigger>Right-click area</hp-context-menu-trigger>
+  <hp-context-menu-content>
+    <hp-context-menu-label>Group Label</hp-context-menu-label>
+    <hp-context-menu-item value="action-1">Action 1</hp-context-menu-item>
+    <hp-context-menu-item value="action-2">Action 2</hp-context-menu-item>
+    <hp-context-menu-separator></hp-context-menu-separator>
+    <hp-context-menu-item value="action-3">Action 3</hp-context-menu-item>
+  </hp-context-menu-content>
+</hp-context-menu>
+```
+
+## Ejemplos de Codigo
+
+<CodeSnippet>
+
+<Flavor only="css">
+
+::: code-group
+
+```html [index.html]
+<hp-context-menu>
+  <hp-context-menu-trigger>
+    <div class="my-area">Right-click here</div>
+  </hp-context-menu-trigger>
+  <hp-context-menu-content>
+    <hp-context-menu-label>Edit</hp-context-menu-label>
+    <hp-context-menu-item value="cut">Cut</hp-context-menu-item>
+    <hp-context-menu-item value="copy">Copy</hp-context-menu-item>
+    <hp-context-menu-item value="paste">Paste</hp-context-menu-item>
+    <hp-context-menu-separator></hp-context-menu-separator>
+    <hp-context-menu-item value="delete">Delete</hp-context-menu-item>
+    <hp-context-menu-item value="archive" disabled>Archive</hp-context-menu-item>
+  </hp-context-menu-content>
+</hp-context-menu>
+```
+
+```css [style.css]
+@import "@headless-primitives/utils/base.css";
+
+hp-context-menu {
+  position: relative;
+  display: block;
+}
+
+hp-context-menu-trigger {
+  display: block;
+}
+
+.my-area {
+  padding: 2rem;
+  border: 2px dashed #e5e7eb;
+  border-radius: 8px;
+  cursor: context-menu;
+  user-select: none;
+}
+
+.my-area:hover {
+  border-color: #3b82f6;
+}
+
+hp-context-menu-trigger[data-state="open"] .my-area {
+  border-color: #3b82f6;
+  border-style: solid;
+}
+
+hp-context-menu-content[data-state="open"] {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+}
+
+hp-context-menu-content[data-state="closed"] {
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+}
+
+hp-context-menu-item[aria-disabled="true"] {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+```
+
+:::
+
+</Flavor>
+
+<Flavor only="tailwind">
+
+::: code-group
+
+```html [index.html]
+<hp-context-menu class="relative block">
+  <hp-context-menu-trigger class="block">
+    <div
+      class="flex items-center justify-center p-8 border-2 border-dashed border-gray-300 rounded-lg cursor-context-menu select-none hover:border-blue-500"
+    >
+      Right-click here
+    </div>
+  </hp-context-menu-trigger>
+  <hp-context-menu-content
+    class="absolute z-50 min-w-48 bg-white border border-gray-300 rounded-md shadow-lg py-1 opacity-0 invisible pointer-events-none data-[state=open]:opacity-100 data-[state=open]:visible data-[state=open]:pointer-events-auto transition-all"
+  >
+    <hp-context-menu-label class="block px-3 py-1 text-xs font-semibold text-gray-500">
+      Edit
+    </hp-context-menu-label>
+    <hp-context-menu-item
+      value="cut"
+      class="flex items-center gap-2 px-3 py-2 text-sm cursor-pointer hover:bg-gray-100"
+    >
+      Cut
+    </hp-context-menu-item>
+    <hp-context-menu-item
+      value="copy"
+      class="flex items-center gap-2 px-3 py-2 text-sm cursor-pointer hover:bg-gray-100"
+    >
+      Copy
+    </hp-context-menu-item>
+    <hp-context-menu-separator class="block h-px my-1 bg-gray-200"></hp-context-menu-separator>
+    <hp-context-menu-item
+      value="delete"
+      class="flex items-center gap-2 px-3 py-2 text-sm cursor-pointer hover:bg-gray-100"
+    >
+      Delete
+    </hp-context-menu-item>
+  </hp-context-menu-content>
+</hp-context-menu>
+```
+
+:::
+
+</Flavor>
+</CodeSnippet>
+
+## API Reference
+
+### `hp-context-menu`
+
+Contenedor raiz del Context Menu. Maneja el estado abierto/cerrado, el posicionamiento y la navegacion por teclado.
+
+#### Atributos
+
+| Atributo   | Tipo      | Descripcion                       |
+| ---------- | --------- | --------------------------------- |
+| `disabled` | `boolean` | Deshabilita el menu completamente |
+| `open`     | `boolean` | Estado abierto/cerrado del popup  |
+
+#### Propiedades
+
+| Propiedad         | Tipo      | Descripcion                                                 |
+| ----------------- | --------- | ----------------------------------------------------------- |
+| `open`            | `boolean` | Getter/setter del estado abierto/cerrado                    |
+| `openMenu(edge?)` | `method`  | Abre el menu; opcionalmente mueve foco a primer/ultimo item |
+| `close()`         | `method`  | Cierra el menu; restaura foco al elemento previo            |
+| `toggle()`        | `method`  | Alterna entre abierto y cerrado                             |
+
+#### Eventos
+
+| Evento         | Detalle                                                                       | Descripcion                                              |
+| -------------- | ----------------------------------------------------------------------------- | -------------------------------------------------------- |
+| `hp-select`    | `{ value: string, label: string \| null, item: HTMLElement }`                 | Emitido cuando el usuario activa un item                 |
+| `hp-highlight` | `{ value: string \| null, label: string \| null, item: HTMLElement \| null }` | Emitido cuando el usuario destaca un item con el teclado |
+| `hp-open`      | —                                                                             | Emitido cuando el popup se abre                          |
+| `hp-close`     | —                                                                             | Emitido cuando el popup se cierra                        |
+
+#### Estados ARIA
+
+| Atributo            | Valores          | Descripcion                 |
+| ------------------- | ---------------- | --------------------------- |
+| `data-hp-component` | `"context-menu"` | Identificador de componente |
+
+---
+
+### `hp-context-menu-trigger`
+
+Area que activa el menu contextual al hacer clic derecho. No es un boton — es un contenedor de contenido.
+
+#### Estados ARIA
+
+| Atributo            | Valores                  | Descripcion                    |
+| ------------------- | ------------------------ | ------------------------------ |
+| `data-state`        | `open \| closed`         | Indica si el menu esta abierto |
+| `data-hp-component` | `"context-menu-trigger"` | Identificador de componente    |
+
+---
+
+### `hp-context-menu-content`
+
+Contenedor del popup que aloja los items, separadores y labels. Se posiciona en las coordenadas del cursor.
+
+#### Estados ARIA
+
+| Atributo                | Valores                  | Descripcion                               |
+| ----------------------- | ------------------------ | ----------------------------------------- |
+| `role`                  | `menu`                   | Segun WAI-ARIA Menu pattern               |
+| `data-state`            | `open \| closed`         | Estado de visibilidad del popup           |
+| `aria-hidden`           | `true \| false`          | Oculto para screen readers cuando cerrado |
+| `aria-activedescendant` | `string`                 | ID del item actualmente destacado         |
+| `data-hp-component`     | `"context-menu-content"` | Identificador de componente               |
+
+---
+
+### `hp-context-menu-item`
+
+Item de accion individual dentro del menu.
+
+#### Atributos
+
+| Atributo   | Tipo                | Descripcion                  |
+| ---------- | ------------------- | ---------------------------- |
+| `value`    | `string` (required) | Identificador unico del item |
+| `disabled` | `boolean`           | Deshabilita el item          |
+
+#### Estados ARIA
+
+| Atributo            | Valores               | Descripcion                          |
+| ------------------- | --------------------- | ------------------------------------ |
+| `role`              | `menuitem`            | Segun WAI-ARIA Menu pattern          |
+| `aria-disabled`     | `true \| false`       | Indica si el item esta deshabilitado |
+| `data-hp-component` | `"context-menu-item"` | Identificador de componente          |
+
+---
+
+### `hp-context-menu-separator`
+
+Separador visual entre grupos de items.
+
+#### Estados ARIA
+
+| Atributo            | Valores                    | Descripcion                 |
+| ------------------- | -------------------------- | --------------------------- |
+| `role`              | `separator`                | Separador segun WAI-ARIA    |
+| `data-hp-component` | `"context-menu-separator"` | Identificador de componente |
+
+---
+
+### `hp-context-menu-label`
+
+Label no interactivo para agrupar items visualmente.
+
+#### Estados ARIA
+
+| Atributo            | Valores                | Descripcion                 |
+| ------------------- | ---------------------- | --------------------------- |
+| `role`              | `presentation`         | No interactivo              |
+| `data-hp-component` | `"context-menu-label"` | Identificador de componente |
+
+---
+
+## Comportamiento del Teclado
+
+| Tecla                 | Contexto   | Accion                                                     |
+| --------------------- | ---------- | ---------------------------------------------------------- |
+| **Clic derecho**      | Trigger    | Abre el menu en las coordenadas del cursor                 |
+| **Shift+F10**         | Trigger    | Abre el menu en el centro del elemento con foco            |
+| **↓ ArrowDown**       | Menu       | Mueve foco al siguiente item (valido)                      |
+| **↑ ArrowUp**         | Menu       | Mueve foco al anterior item (valido)                       |
+| **Home**              | Menu       | Mueve foco al primer item (valido)                         |
+| **End**               | Menu       | Mueve foco al ultimo item (valido)                         |
+| **Enter** / **Space** | Item       | Activa el item y cierra el menu                            |
+| **Escape**            | Cualquiera | Cierra el menu; foco vuelve al elemento previamente activo |
+| **Tab**               | Menu       | Cierra el menu (comportamiento natural del foco)           |
+
+## Accesibilidad
+
+- ✅ Implementa WAI-ARIA **Menu** pattern con activacion por clic derecho
+- ✅ Navegacion completa por teclado (Shift+F10, Arrows, Home, End, Enter, Space, Escape, Tab)
+- ✅ Roles ARIA correctos: `menu` (content), `menuitem` (items), `separator`, `presentation` (labels)
+- ✅ Focus management automatico con RovingTabindex
+- ✅ Atributos `aria-hidden`, `aria-disabled`, `aria-activedescendant`
+- ✅ Posicionamiento en coordenadas del cursor
+- ✅ Indicador visual de foco (`outline-2`)
+- ✅ Soporte para `prefers-reduced-motion`
+- ✅ Items deshabilitados excluidos de la navegacion por teclado
+- ✅ Singleton: solo un context menu abierto a la vez

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -15,6 +15,7 @@
     "@headless-primitives/checkbox": "workspace:*",
     "@headless-primitives/collapsible": "workspace:*",
     "@headless-primitives/combobox": "workspace:*",
+    "@headless-primitives/context-menu": "workspace:*",
     "@headless-primitives/dialog": "workspace:*",
     "@headless-primitives/drawer": "workspace:*",
     "@headless-primitives/dropdown-menu": "workspace:*",

--- a/apps/playground/index.html
+++ b/apps/playground/index.html
@@ -39,6 +39,7 @@
             <li><button class="nav-item" data-comp="checkbox">Checkbox</button></li>
             <li><button class="nav-item" data-comp="collapsible">Collapsible</button></li>
             <li><button class="nav-item" data-comp="combobox">Combobox</button></li>
+            <li><button class="nav-item" data-comp="context-menu">Context Menu</button></li>
             <li><button class="nav-item" data-comp="dialog">Dialog</button></li>
             <li><button class="nav-item" data-comp="dropdown-menu">Dropdown Menu</button></li>
             <li><button class="nav-item" data-comp="drawer">Drawer</button></li>

--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -16,6 +16,7 @@
     "@headless-primitives/checkbox": "workspace:*",
     "@headless-primitives/collapsible": "workspace:*",
     "@headless-primitives/combobox": "workspace:*",
+    "@headless-primitives/context-menu": "workspace:*",
     "@headless-primitives/dialog": "workspace:*",
     "@headless-primitives/drawer": "workspace:*",
     "@headless-primitives/dropdown-menu": "workspace:*",

--- a/apps/playground/src/demos/context-menu.css
+++ b/apps/playground/src/demos/context-menu.css
@@ -1,0 +1,184 @@
+/**
+ * Demo styles for hp-context-menu component
+ * These are example styles — consumers should create their own
+ */
+
+.demo-context-menu {
+  position: relative;
+  display: block;
+}
+
+.demo-cm-trigger {
+  display: block;
+}
+
+.demo-cm-trigger-area {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 2rem;
+  min-height: 120px;
+  font-family: inherit;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #1f2937;
+  background-color: #f9fafb;
+  border: 2px dashed #d1d5db;
+  border-radius: 8px;
+  cursor: context-menu;
+  user-select: none;
+  transition: all 0.15s ease;
+}
+
+.demo-cm-trigger-area:hover {
+  border-color: #2563eb;
+  background-color: #eff6ff;
+}
+
+.demo-cm-trigger-area--disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  border-style: solid;
+}
+
+.demo-cm-trigger-area--disabled:hover {
+  border-color: #d1d5db;
+  background-color: #f9fafb;
+}
+
+hp-context-menu-trigger[data-state="open"] .demo-cm-trigger-area {
+  border-color: #2563eb;
+  background-color: #dbeafe;
+  border-style: solid;
+}
+
+.demo-cm-content {
+  position: absolute;
+  z-index: 50;
+  min-width: 12rem;
+  overflow-y: auto;
+  background-color: #ffffff;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  padding: 0.25rem 0;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition:
+    opacity 0.15s ease,
+    visibility 0.15s ease;
+}
+
+.demo-cm-content[data-state="open"] {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+}
+
+.demo-cm-content[data-state="closed"] {
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+}
+
+hp-context-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  font-family: inherit;
+  font-size: 0.875rem;
+  color: #1f2937;
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  user-select: none;
+  text-align: left;
+  transition: background-color 0.1s ease;
+  box-sizing: border-box;
+  min-height: 2rem;
+}
+
+hp-context-menu-item:hover:not([aria-disabled="true"]) {
+  background-color: #f3f4f6;
+}
+
+hp-context-menu-item:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: -2px;
+}
+
+hp-context-menu-item[aria-disabled="true"],
+hp-context-menu-item[disabled] {
+  opacity: 0.5;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+hp-context-menu-separator {
+  height: 1px;
+  margin: 0.25rem 0;
+  background-color: #e5e7eb;
+}
+
+hp-context-menu-label {
+  padding: 0.375rem 0.75rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #6b7280;
+  user-select: none;
+}
+
+/* Dark mode support */
+@media (prefers-color-scheme: dark) {
+  .demo-cm-trigger-area {
+    color: #f3f4f6;
+    background-color: #111827;
+    border-color: #374151;
+  }
+
+  .demo-cm-trigger-area:hover {
+    border-color: #3b82f6;
+    background-color: #0f172a;
+  }
+
+  hp-context-menu-trigger[data-state="open"] .demo-cm-trigger-area {
+    border-color: #3b82f6;
+    background-color: #0c2d4a;
+  }
+
+  .demo-cm-content {
+    background-color: #111827;
+    border-color: #374151;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+  }
+
+  hp-context-menu-item {
+    color: #f3f4f6;
+  }
+
+  hp-context-menu-item:hover:not([aria-disabled="true"]) {
+    background-color: #1f2937;
+  }
+
+  hp-context-menu-separator {
+    background-color: #374151;
+  }
+
+  hp-context-menu-label {
+    color: #9ca3af;
+  }
+}
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .demo-cm-trigger-area,
+  .demo-cm-content,
+  hp-context-menu-item {
+    transition: none;
+  }
+}

--- a/apps/playground/src/demos/context-menu.demo.ts
+++ b/apps/playground/src/demos/context-menu.demo.ts
@@ -1,0 +1,93 @@
+import { ComponentDemo } from "../types";
+import "./context-menu.css";
+
+export const contextMenuDemo: ComponentDemo = {
+  title: "Context Menu primitive",
+  description:
+    "WAI-ARIA Menu activado por clic derecho, con navegación por teclado, separadores y labels de grupo.",
+  html: `
+    <div style="display: flex; flex-direction: column; gap: 2rem; max-width: 500px;">
+      <!-- Basic context menu -->
+      <div>
+        <label style="display: block; margin-bottom: 0.5rem; font-size: 0.875rem; font-weight: 500;">
+          Área con menú contextual
+        </label>
+        <hp-context-menu id="ctx-menu" class="demo-context-menu">
+          <hp-context-menu-trigger class="demo-cm-trigger">
+            <div class="demo-cm-trigger-area">
+              <span style="font-size: 1.5rem;">🖱️</span>
+              <span>Haz clic derecho aquí</span>
+              <span style="font-size: 0.75rem; opacity: 0.6;">(o Shift+F10)</span>
+            </div>
+          </hp-context-menu-trigger>
+          <hp-context-menu-content class="demo-cm-content">
+            <hp-context-menu-label>Edit</hp-context-menu-label>
+            <hp-context-menu-item value="cut">✂️ Cut</hp-context-menu-item>
+            <hp-context-menu-item value="copy">📋 Copy</hp-context-menu-item>
+            <hp-context-menu-item value="paste">📌 Paste</hp-context-menu-item>
+            <hp-context-menu-separator></hp-context-menu-separator>
+            <hp-context-menu-label>Danger Zone</hp-context-menu-label>
+            <hp-context-menu-item value="delete">🗑️ Delete</hp-context-menu-item>
+            <hp-context-menu-item value="archive" disabled>📦 Archive (disabled)</hp-context-menu-item>
+          </hp-context-menu-content>
+        </hp-context-menu>
+      </div>
+
+      <!-- Disabled context menu -->
+      <div>
+        <label style="display: block; margin-bottom: 0.5rem; font-size: 0.875rem; font-weight: 500;">
+          Área deshabilitada
+        </label>
+        <hp-context-menu class="demo-context-menu" disabled>
+          <hp-context-menu-trigger class="demo-cm-trigger">
+            <div class="demo-cm-trigger-area demo-cm-trigger-area--disabled">
+              <span>Menú contextual deshabilitado</span>
+            </div>
+          </hp-context-menu-trigger>
+          <hp-context-menu-content class="demo-cm-content">
+            <hp-context-menu-item value="noop">Nothing</hp-context-menu-item>
+          </hp-context-menu-content>
+        </hp-context-menu>
+      </div>
+
+      <!-- Event log -->
+      <div style="padding: 1rem; background: #f5f5f5; border-radius: 6px; font-family: monospace; font-size: 0.875rem;">
+        <div style="font-weight: 600; margin-bottom: 0.5rem;">Event Log:</div>
+        <div id="cm-event-log" style="max-height: 200px; overflow-y: auto; white-space: pre-wrap; word-break: break-word; color: #333;">
+          (events will appear here)
+        </div>
+      </div>
+    </div>
+  `,
+  init: () => {
+    const menu = document.getElementById("ctx-menu") as any;
+    const eventLog = document.getElementById("cm-event-log")!;
+    let logCount = 0;
+
+    function logEvent(msg: string) {
+      logCount++;
+      const timestamp = new Date().toLocaleTimeString();
+      eventLog.textContent = `[${logCount}] ${timestamp}: ${msg}\n${eventLog.textContent}`;
+      if (logCount > 20) {
+        eventLog.textContent = eventLog.textContent.split("\n").slice(0, 20).join("\n");
+      }
+    }
+
+    if (menu) {
+      menu.addEventListener("hp-select", (e: any) => {
+        logEvent(`Item selected: value="${e.detail.value}" label="${e.detail.label}"`);
+      });
+      menu.addEventListener("hp-highlight", (e: any) => {
+        logEvent(`Item highlighted: value="${e.detail.value}"`);
+      });
+      menu.addEventListener("hp-open", () => {
+        logEvent("Context menu opened");
+      });
+      menu.addEventListener("hp-close", () => {
+        logEvent("Context menu closed");
+      });
+    }
+
+    logEvent("Demo initialized. Right-click the area above!");
+  },
+};

--- a/apps/playground/src/main.ts
+++ b/apps/playground/src/main.ts
@@ -10,6 +10,7 @@ import "@headless-primitives/button";
 import "@headless-primitives/checkbox";
 import "@headless-primitives/collapsible";
 import "@headless-primitives/combobox";
+import "@headless-primitives/context-menu";
 import "@headless-primitives/dialog";
 import "@headless-primitives/dropdown-menu";
 import "@headless-primitives/drawer";
@@ -39,6 +40,7 @@ import { buttonDemo } from "./demos/button.demo";
 import { checkboxDemo } from "./demos/checkbox.demo";
 import { collapsibleDemo } from "./demos/collapsible.demo";
 import { comboboxDemo } from "./demos/combobox.demo";
+import { contextMenuDemo } from "./demos/context-menu.demo";
 import { dialogDemo } from "./demos/dialog.demo";
 import { dropdownMenuDemo } from "./demos/dropdown-menu.demo";
 import { drawerDemo } from "./demos/drawer.demo";
@@ -66,6 +68,7 @@ const ROUTES: Record<string, ComponentDemo> = {
   checkbox: checkboxDemo,
   collapsible: collapsibleDemo,
   combobox: comboboxDemo,
+  "context-menu": contextMenuDemo,
   dialog: dialogDemo,
   "dropdown-menu": dropdownMenuDemo,
   drawer: drawerDemo,

--- a/packages/vanilla/context-menu/package.json
+++ b/packages/vanilla/context-menu/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@headless-primitives/context-menu",
+  "version": "0.1.0",
+  "description": "Headless context menu primitive (right-click triggered action menu)",
+  "keywords": [
+    "context-menu",
+    "headless",
+    "lit",
+    "menu",
+    "right-click",
+    "web-components"
+  ],
+  "homepage": "https://davidcast27.github.io/headless-primitives/",
+  "bugs": {
+    "url": "https://github.com/DavidCast27/headless-primitives/issues"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DavidCast27/headless-primitives.git"
+  },
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "sideEffects": false,
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "vite build && tsc",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@headless-primitives/utils": "workspace:*",
+    "lit": "^3.3.2"
+  },
+  "devDependencies": {
+    "happy-dom": "^14.12.3",
+    "typescript": "^5.4.0",
+    "vite": "^5.4.2",
+    "vitest": "^2.0.5"
+  },
+  "peerDependencies": {
+    "lit": "^3.3.2"
+  }
+}

--- a/packages/vanilla/context-menu/src/context-menu.test.ts
+++ b/packages/vanilla/context-menu/src/context-menu.test.ts
@@ -1,0 +1,285 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import "./index";
+import type { HeadlessContextMenu } from "./context-menu";
+
+describe("HpContextMenu", () => {
+  let root: HeadlessContextMenu;
+
+  function createBasic() {
+    const el = document.createElement("hp-context-menu");
+    el.innerHTML = `
+      <hp-context-menu-trigger>Right-click here</hp-context-menu-trigger>
+      <hp-context-menu-content>
+        <hp-context-menu-label>Edit</hp-context-menu-label>
+        <hp-context-menu-item value="cut">Cut</hp-context-menu-item>
+        <hp-context-menu-item value="copy">Copy</hp-context-menu-item>
+        <hp-context-menu-item value="paste">Paste</hp-context-menu-item>
+        <hp-context-menu-separator></hp-context-menu-separator>
+        <hp-context-menu-item value="delete" disabled>Delete</hp-context-menu-item>
+      </hp-context-menu-content>
+    `;
+    return el as HeadlessContextMenu;
+  }
+
+  function rightClick(target: Element, x = 100, y = 200) {
+    target.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, clientX: x, clientY: y }));
+  }
+
+  beforeEach(() => {
+    root = createBasic();
+    document.body.appendChild(root);
+  });
+
+  afterEach(() => {
+    root.remove();
+  });
+
+  // --- Structure tests ---
+
+  it("sets data-hp-component on root", () => {
+    expect(root.getAttribute("data-hp-component")).toBe("context-menu");
+  });
+
+  it("sets data-hp-component on trigger", () => {
+    const trigger = root.querySelector("hp-context-menu-trigger")!;
+    expect(trigger.getAttribute("data-hp-component")).toBe("context-menu-trigger");
+  });
+
+  it("sets data-hp-component on content", () => {
+    const content = root.querySelector("hp-context-menu-content")!;
+    expect(content.getAttribute("data-hp-component")).toBe("context-menu-content");
+  });
+
+  it("sets data-hp-component on items", () => {
+    const items = root.querySelectorAll("hp-context-menu-item");
+    for (const item of items) {
+      expect(item.getAttribute("data-hp-component")).toBe("context-menu-item");
+    }
+  });
+
+  // --- ARIA tests ---
+
+  it("sets role=menu on content and data-state=closed initially", () => {
+    const content = root.querySelector("hp-context-menu-content")!;
+    expect(content.getAttribute("role")).toBe("menu");
+    expect(content.getAttribute("data-state")).toBe("closed");
+    expect(content.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("sets role=menuitem on items", () => {
+    const items = root.querySelectorAll("hp-context-menu-item");
+    for (const item of items) {
+      expect(item.getAttribute("role")).toBe("menuitem");
+    }
+  });
+
+  it("sets role=separator on separator", () => {
+    const separator = root.querySelector("hp-context-menu-separator")!;
+    expect(separator.getAttribute("role")).toBe("separator");
+  });
+
+  it("sets role=presentation on label", () => {
+    const label = root.querySelector("hp-context-menu-label")!;
+    expect(label.getAttribute("role")).toBe("presentation");
+  });
+
+  it("sets aria-disabled on disabled items", () => {
+    const disabledItem = root.querySelector('hp-context-menu-item[value="delete"]')!;
+    expect(disabledItem.getAttribute("aria-disabled")).toBe("true");
+
+    const enabledItem = root.querySelector('hp-context-menu-item[value="cut"]')!;
+    expect(enabledItem.getAttribute("aria-disabled")).toBe("false");
+  });
+
+  it("trigger does NOT have role=button or aria-haspopup", () => {
+    const trigger = root.querySelector("hp-context-menu-trigger")!;
+    expect(trigger.hasAttribute("role")).toBe(false);
+    expect(trigger.hasAttribute("aria-haspopup")).toBe(false);
+    expect(trigger.hasAttribute("aria-expanded")).toBe(false);
+  });
+
+  it("items have tabindex=-1 by default", () => {
+    const items = root.querySelectorAll("hp-context-menu-item");
+    for (const item of items) {
+      expect(item.hasAttribute("tabindex")).toBe(true);
+    }
+  });
+
+  // --- Right-click trigger tests ---
+
+  it("opens on right-click (contextmenu event)", () => {
+    const trigger = root.querySelector("hp-context-menu-trigger")!;
+    const content = root.querySelector("hp-context-menu-content")!;
+
+    rightClick(trigger);
+    expect(content.getAttribute("data-state")).toBe("open");
+    expect(content.getAttribute("aria-hidden")).toBe("false");
+  });
+
+  it("sets data-state on trigger when open", () => {
+    const trigger = root.querySelector("hp-context-menu-trigger")!;
+
+    expect(trigger.getAttribute("data-state")).toBe("closed");
+    rightClick(trigger);
+    expect(trigger.getAttribute("data-state")).toBe("open");
+  });
+
+  it("opens with Shift+F10 keyboard shortcut", () => {
+    const trigger = root.querySelector("hp-context-menu-trigger")!;
+    const content = root.querySelector("hp-context-menu-content")!;
+
+    trigger.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "F10", shiftKey: true, bubbles: true }),
+    );
+    expect(content.getAttribute("data-state")).toBe("open");
+  });
+
+  // --- Open/close tests ---
+
+  it("closes with Escape key", () => {
+    const trigger = root.querySelector("hp-context-menu-trigger")!;
+    const content = root.querySelector("hp-context-menu-content")!;
+
+    rightClick(trigger);
+    expect(content.getAttribute("data-state")).toBe("open");
+
+    content.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    expect(content.getAttribute("data-state")).toBe("closed");
+  });
+
+  it("disabled root prevents opening", () => {
+    root.disabled = true;
+    const trigger = root.querySelector("hp-context-menu-trigger")!;
+    const content = root.querySelector("hp-context-menu-content")!;
+
+    rightClick(trigger);
+    expect(content.getAttribute("data-state")).toBe("closed");
+  });
+
+  it("disabled root prevents openMenu()", () => {
+    root.disabled = true;
+    root.openMenu();
+    const content = root.querySelector("hp-context-menu-content")!;
+    expect(content.getAttribute("data-state")).toBe("closed");
+  });
+
+  it("closes after item activation", () => {
+    const trigger = root.querySelector("hp-context-menu-trigger")!;
+    const content = root.querySelector("hp-context-menu-content")!;
+
+    rightClick(trigger);
+    expect(content.getAttribute("data-state")).toBe("open");
+
+    const item = root.querySelector('hp-context-menu-item[value="paste"]')!;
+    item.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(content.getAttribute("data-state")).toBe("closed");
+  });
+
+  it("toggle() opens then closes", () => {
+    const content = root.querySelector("hp-context-menu-content")!;
+    root.toggle();
+    expect(content.getAttribute("data-state")).toBe("open");
+    root.toggle();
+    expect(content.getAttribute("data-state")).toBe("closed");
+  });
+
+  // --- Event tests ---
+
+  it("emits hp-select event on item activation", () => {
+    let detail: any = null;
+    root.addEventListener("hp-select", ((e: CustomEvent) => {
+      detail = e.detail;
+    }) as EventListener);
+
+    root.openMenu();
+
+    const item = root.querySelector('hp-context-menu-item[value="copy"]')!;
+    item.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    expect(detail).not.toBeNull();
+    expect(detail.value).toBe("copy");
+    expect(detail.label).toBe("Copy");
+  });
+
+  it("does not activate disabled items on click", () => {
+    let selectFired = false;
+    root.addEventListener("hp-select", () => {
+      selectFired = true;
+    });
+
+    root.openMenu();
+
+    const disabledItem = root.querySelector('hp-context-menu-item[value="delete"]')!;
+    disabledItem.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    expect(selectFired).toBe(false);
+  });
+
+  // --- Keyboard navigation tests ---
+
+  it("activates item with Enter key in menu", () => {
+    let detail: any = null;
+    root.addEventListener("hp-select", ((e: CustomEvent) => {
+      detail = e.detail;
+    }) as EventListener);
+
+    root.openMenu("first");
+
+    const content = root.querySelector("hp-context-menu-content")!;
+    content.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+
+    expect(detail).not.toBeNull();
+    expect(detail.value).toBe("cut");
+  });
+
+  it("navigates with ArrowDown in menu", () => {
+    root.openMenu("first");
+    const content = root.querySelector("hp-context-menu-content")!;
+
+    // First active should be "cut" (first non-disabled)
+    // ArrowDown should move to "copy"
+    content.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
+
+    const activeId = content.getAttribute("aria-activedescendant");
+    const activeItem = root.querySelector(`#${activeId}`);
+    expect(activeItem?.getAttribute("value")).toBe("copy");
+  });
+
+  it("skips disabled items during navigation", () => {
+    root.openMenu("first");
+    const content = root.querySelector("hp-context-menu-content")!;
+
+    // Navigate: cut -> copy -> paste -> (skip delete) -> cut
+    content.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
+    content.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
+    content.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
+
+    const activeId = content.getAttribute("aria-activedescendant");
+    const activeItem = root.querySelector(`#${activeId}`);
+    // Should wrap to "cut" (skipping disabled "delete")
+    expect(activeItem?.getAttribute("value")).toBe("cut");
+  });
+
+  it("navigates to last item with End key", () => {
+    root.openMenu("first");
+    const content = root.querySelector("hp-context-menu-content")!;
+
+    content.dispatchEvent(new KeyboardEvent("keydown", { key: "End", bubbles: true }));
+
+    const activeId = content.getAttribute("aria-activedescendant");
+    const activeItem = root.querySelector(`#${activeId}`);
+    // Last non-disabled item is "paste"
+    expect(activeItem?.getAttribute("value")).toBe("paste");
+  });
+
+  it("navigates to first item with Home key", () => {
+    root.openMenu("last");
+    const content = root.querySelector("hp-context-menu-content")!;
+
+    content.dispatchEvent(new KeyboardEvent("keydown", { key: "Home", bubbles: true }));
+
+    const activeId = content.getAttribute("aria-activedescendant");
+    const activeItem = root.querySelector(`#${activeId}`);
+    expect(activeItem?.getAttribute("value")).toBe("cut");
+  });
+});

--- a/packages/vanilla/context-menu/src/context-menu.ts
+++ b/packages/vanilla/context-menu/src/context-menu.ts
@@ -1,0 +1,377 @@
+import { HeadlessElement, customElement, RovingTabindex } from "@headless-primitives/utils";
+import { property } from "lit/decorators.js";
+import type { ContextMenuSelectDetail, ContextMenuHighlightDetail } from "./types";
+
+@customElement("hp-context-menu")
+export class HeadlessContextMenu extends HeadlessElement {
+  static _currentOpen: HeadlessContextMenu | null = null;
+
+  private _open = false;
+  private _trigger: HeadlessContextMenuTrigger | null = null;
+  private _content: HeadlessContextMenuContent | null = null;
+  private _items: HeadlessContextMenuItem[] = [];
+  private _activeIndex: number = -1;
+  private _cursorX = 0;
+  private _cursorY = 0;
+  private _previousFocus: HTMLElement | null = null;
+  private _scrollParents: EventTarget[] = [];
+
+  @property({ type: Boolean, reflect: true }) disabled = false;
+
+  @property({ type: Boolean, reflect: true })
+  get open(): boolean {
+    return this._open;
+  }
+  set open(v: boolean) {
+    this._open = Boolean(v);
+    this._sync();
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.setAttribute("data-hp-component", "context-menu");
+    this._setupRefs();
+    this._bind();
+    this._sync();
+    requestAnimationFrame(() => this._sync());
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this._removeGlobalListeners();
+    if (HeadlessContextMenu._currentOpen === this) {
+      HeadlessContextMenu._currentOpen = null;
+    }
+  }
+
+  private _setupRefs() {
+    this._trigger = this.querySelector("hp-context-menu-trigger");
+    this._content = this.querySelector("hp-context-menu-content");
+    this._items = Array.from(this.querySelectorAll("hp-context-menu-item"));
+  }
+
+  private _bind() {
+    if (this._trigger) {
+      this._trigger.addEventListener("contextmenu", this._onContextMenu);
+      this._trigger.addEventListener("keydown", this._onTriggerKeyDown);
+    }
+    if (this._content) {
+      this._content.addEventListener("keydown", this._onMenuKeyDown);
+    }
+    for (const item of this._items) {
+      item.addEventListener("click", this._onItemClick as EventListener);
+    }
+  }
+
+  private _setupRoving() {
+    if (!this._content) return;
+    const focusables = this._items.filter((i) => !i.disabled);
+    new RovingTabindex(focusables as unknown as HTMLElement[], (el) => {
+      const idx = this._items.indexOf(el as unknown as HeadlessContextMenuItem);
+      this._setActiveIndex(idx);
+    });
+    focusables.forEach((el, idx) => {
+      el.setAttribute("tabindex", idx === 0 ? "0" : "-1");
+    });
+  }
+
+  private _computePosition() {
+    if (!this._content) return;
+    const rootRect = this.getBoundingClientRect();
+    const left = this._cursorX - rootRect.left;
+    const top = this._cursorY - rootRect.top;
+    this._content.style.left = `${left}px`;
+    this._content.style.top = `${top}px`;
+  }
+
+  private _onContextMenu = (e: MouseEvent) => {
+    if (this.disabled) return;
+    e.preventDefault();
+    e.stopPropagation();
+    this._cursorX = e.clientX;
+    this._cursorY = e.clientY;
+    this._previousFocus = document.activeElement as HTMLElement | null;
+
+    // Close any other open context menu
+    if (HeadlessContextMenu._currentOpen && HeadlessContextMenu._currentOpen !== this) {
+      HeadlessContextMenu._currentOpen.close();
+    }
+
+    this.openMenu("first");
+  };
+
+  private _onTriggerKeyDown = (e: KeyboardEvent) => {
+    if (this.disabled) return;
+    // Shift+F10 or ContextMenu key opens the context menu
+    if ((e.key === "F10" && e.shiftKey) || e.key === "ContextMenu") {
+      e.preventDefault();
+      // Position at center of the focused element
+      const target = (document.activeElement || this._trigger) as HTMLElement;
+      const rect = target.getBoundingClientRect();
+      this._cursorX = rect.left + rect.width / 2;
+      this._cursorY = rect.top + rect.height / 2;
+      this._previousFocus = target;
+
+      if (HeadlessContextMenu._currentOpen && HeadlessContextMenu._currentOpen !== this) {
+        HeadlessContextMenu._currentOpen.close();
+      }
+
+      this.openMenu("first");
+    }
+  };
+
+  private _onMenuKeyDown = (e: KeyboardEvent) => {
+    if (!this.open) return;
+    const activeItem = this._items[this._activeIndex];
+    switch (e.key) {
+      case "ArrowDown":
+      case "ArrowRight":
+        e.preventDefault();
+        this._moveActive(1);
+        break;
+      case "ArrowUp":
+      case "ArrowLeft":
+        e.preventDefault();
+        this._moveActive(-1);
+        break;
+      case "Home":
+        e.preventDefault();
+        this._moveToEdge("first");
+        break;
+      case "End":
+        e.preventDefault();
+        this._moveToEdge("last");
+        break;
+      case "Enter":
+      case " ":
+        e.preventDefault();
+        if (activeItem && !activeItem.disabled) {
+          this._activateItem(activeItem);
+        }
+        break;
+      case "Escape":
+        e.preventDefault();
+        this.close();
+        break;
+      case "Tab":
+        this.close();
+        break;
+    }
+  };
+
+  private _onItemClick = (e: MouseEvent) => {
+    const item = e.currentTarget as HeadlessContextMenuItem;
+    if (item.disabled) return;
+    this._activateItem(item);
+  };
+
+  private _activateItem(item: HeadlessContextMenuItem) {
+    const detail: ContextMenuSelectDetail = {
+      value: item.value,
+      label: item.textContent?.trim() || null,
+      item: item,
+    };
+    this.emit("select", detail);
+    this.close();
+  }
+
+  private _emitHighlight() {
+    const active = this._items[this._activeIndex] || null;
+    const detail: ContextMenuHighlightDetail = {
+      value: active ? active.value : null,
+      label: active ? active.textContent?.trim() || null : null,
+      item: active,
+    };
+    this.emit("highlight", detail);
+  }
+
+  private _moveActive(delta: number) {
+    const enabled = this._items.filter((i) => !i.disabled);
+    if (enabled.length === 0) return;
+    const current = this._items[this._activeIndex];
+    let idx = enabled.indexOf(current as HeadlessContextMenuItem);
+    if (idx === -1) idx = 0;
+    const next = (idx + delta + enabled.length) % enabled.length;
+    const target = enabled[next];
+    this._setActiveIndex(this._items.indexOf(target));
+  }
+
+  private _moveToEdge(edge: "first" | "last") {
+    const enabled = this._items.filter((i) => !i.disabled);
+    if (enabled.length === 0) return;
+    const target = edge === "first" ? enabled[0] : enabled[enabled.length - 1];
+    this._setActiveIndex(this._items.indexOf(target));
+  }
+
+  private _setActiveIndex(index: number) {
+    if (!this._content) return;
+    if (index < 0 || index >= this._items.length) return;
+    this._activeIndex = index;
+    const active = this._items[index];
+    if (active) {
+      if (!active.id) active.id = `hp-context-menu-item-${active.hpId}`;
+      this._content.setAttribute("aria-activedescendant", active.id);
+      active.scrollIntoView({ block: "nearest" });
+      this._emitHighlight();
+    }
+  }
+
+  private _sync() {
+    this._setupRefs();
+
+    // trigger state
+    if (this._trigger) {
+      this._trigger.setAttribute("data-state", this._open ? "open" : "closed");
+    }
+
+    // content ARIA/state
+    if (this._content) {
+      this._content.setAttribute("role", "menu");
+      this._content.setAttribute("data-state", this._open ? "open" : "closed");
+      this._content.setAttribute("aria-hidden", this._open ? "false" : "true");
+      if (!this._content.id) this._content.id = `hp-context-menu-content-${this.hpId}`;
+    }
+
+    // items ARIA
+    for (const item of this._items) {
+      item.setAttribute("role", "menuitem");
+      item.setAttribute("aria-disabled", String(item.disabled));
+    }
+
+    if (this._open) {
+      HeadlessContextMenu._currentOpen = this;
+      this._setupRoving();
+      const startIndex = this._items.findIndex((i) => !i.disabled);
+      if (startIndex >= 0) this._setActiveIndex(startIndex);
+
+      this._computePosition();
+      document.addEventListener("click", this._onClickOutside);
+      document.addEventListener("contextmenu", this._onClickOutside);
+      document.addEventListener("keydown", this._onGlobalKeydown);
+      if (this._trigger) {
+        this._scrollParents = this._getScrollParents(this._trigger);
+        for (const parent of this._scrollParents) {
+          parent.addEventListener("scroll", this._onScrollOrResize, {
+            passive: true,
+          } as AddEventListenerOptions);
+        }
+      }
+      window.addEventListener("resize", this._onScrollOrResize, { passive: true });
+      this.emit("open");
+    } else {
+      if (HeadlessContextMenu._currentOpen === this) {
+        HeadlessContextMenu._currentOpen = null;
+      }
+      this._removeGlobalListeners();
+      this.emit("close");
+    }
+  }
+
+  private _getScrollParents(el: HTMLElement): EventTarget[] {
+    const parents: EventTarget[] = [];
+    let node: HTMLElement | null = el.parentElement;
+    while (node) {
+      const { overflow, overflowY, overflowX } = getComputedStyle(node);
+      if (/auto|scroll|overlay/.test(overflow + overflowY + overflowX)) parents.push(node);
+      node = node.parentElement;
+    }
+    parents.push(window);
+    return parents;
+  }
+
+  private _removeGlobalListeners() {
+    document.removeEventListener("click", this._onClickOutside);
+    document.removeEventListener("contextmenu", this._onClickOutside);
+    document.removeEventListener("keydown", this._onGlobalKeydown);
+    for (const parent of this._scrollParents) {
+      parent.removeEventListener("scroll", this._onScrollOrResize);
+    }
+    this._scrollParents = [];
+    window.removeEventListener("resize", this._onScrollOrResize);
+  }
+
+  private _onClickOutside = (e: MouseEvent) => {
+    if (!this._open || !this._content) return;
+    const target = e.target as Node;
+    if (!this._content.contains(target)) this.close();
+  };
+
+  private _onGlobalKeydown = (e: KeyboardEvent) => {
+    if (e.key === "Escape" && this._open) {
+      e.preventDefault();
+      this.close();
+    }
+  };
+
+  private _onScrollOrResize = () => {
+    if (this._open) this.close();
+  };
+
+  // Public API
+  openMenu(edge?: "first" | "last") {
+    if (this.disabled) return;
+    this.open = true;
+    if (edge) this._moveToEdge(edge);
+  }
+
+  close() {
+    this.open = false;
+    // Restore focus to previously focused element
+    if (this._previousFocus && typeof this._previousFocus.focus === "function") {
+      this._previousFocus.focus();
+      this._previousFocus = null;
+    }
+  }
+
+  toggle() {
+    this.open = !this.open;
+  }
+}
+
+@customElement("hp-context-menu-trigger")
+export class HeadlessContextMenuTrigger extends HeadlessElement {
+  connectedCallback() {
+    super.connectedCallback();
+    this.setAttribute("data-hp-component", "context-menu-trigger");
+  }
+}
+
+@customElement("hp-context-menu-content")
+export class HeadlessContextMenuContent extends HeadlessElement {
+  connectedCallback() {
+    super.connectedCallback();
+    this.setAttribute("data-hp-component", "context-menu-content");
+    if (!this.id) this.id = `hp-context-menu-content-${this.hpId}`;
+  }
+}
+
+@customElement("hp-context-menu-item")
+export class HeadlessContextMenuItem extends HeadlessElement {
+  @property({ type: String, reflect: true }) value = "";
+  @property({ type: Boolean, reflect: true }) disabled = false;
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.setAttribute("data-hp-component", "context-menu-item");
+    if (!this.id) this.id = `hp-context-menu-item-${this.hpId}`;
+    if (!this.hasAttribute("tabindex")) this.setAttribute("tabindex", "-1");
+  }
+}
+
+@customElement("hp-context-menu-separator")
+export class HeadlessContextMenuSeparator extends HeadlessElement {
+  connectedCallback() {
+    super.connectedCallback();
+    this.setAttribute("data-hp-component", "context-menu-separator");
+    this.setAttribute("role", "separator");
+  }
+}
+
+@customElement("hp-context-menu-label")
+export class HeadlessContextMenuLabel extends HeadlessElement {
+  connectedCallback() {
+    super.connectedCallback();
+    this.setAttribute("data-hp-component", "context-menu-label");
+    this.setAttribute("role", "presentation");
+  }
+}

--- a/packages/vanilla/context-menu/src/index.ts
+++ b/packages/vanilla/context-menu/src/index.ts
@@ -1,0 +1,9 @@
+export {
+  HeadlessContextMenu,
+  HeadlessContextMenuTrigger,
+  HeadlessContextMenuContent,
+  HeadlessContextMenuItem,
+  HeadlessContextMenuSeparator,
+  HeadlessContextMenuLabel,
+} from "./context-menu";
+export type { ContextMenuSelectDetail, ContextMenuHighlightDetail } from "./types";

--- a/packages/vanilla/context-menu/src/types.ts
+++ b/packages/vanilla/context-menu/src/types.ts
@@ -1,0 +1,11 @@
+export interface ContextMenuSelectDetail {
+  value: string;
+  label: string | null;
+  item: HTMLElement;
+}
+
+export interface ContextMenuHighlightDetail {
+  value: string | null;
+  label: string | null;
+  item: HTMLElement | null;
+}

--- a/packages/vanilla/context-menu/tsconfig.json
+++ b/packages/vanilla/context-menu/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "emitDeclarationOnly": true
+  },
+  "include": ["src"]
+}

--- a/packages/vanilla/context-menu/vite.config.ts
+++ b/packages/vanilla/context-menu/vite.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "vitest/config";
+import { resolve } from "path";
+
+export default defineConfig({
+  build: {
+    lib: {
+      entry: resolve(__dirname, "src/index.ts"),
+      name: "HeadlessPrimitivesContextMenu",
+      fileName: "index",
+    },
+    target: "esnext",
+  },
+  test: {
+    environment: "happy-dom",
+  },
+});

--- a/packages/vanilla/styles/package.json
+++ b/packages/vanilla/styles/package.json
@@ -25,6 +25,7 @@
     "./select.css": "./src/select.css",
     "./combobox.css": "./src/combobox.css",
     "./dropdown-menu.css": "./src/dropdown-menu.css",
+    "./context-menu.css": "./src/context-menu.css",
     "./atoms.css": "./src/atoms.css",
     "./field.css": "./src/field.css",
     "./verify-aria.js": "./src/verify-aria.js"

--- a/packages/vanilla/styles/src/context-menu.css
+++ b/packages/vanilla/styles/src/context-menu.css
@@ -1,0 +1,98 @@
+/**
+ * @headless-primitives/styles — hp-context-menu
+ *
+ * Optional theming layer for `hp-context-menu`.
+ * Structural/functional styles live in `@headless-primitives/utils/base.css`.
+ *
+ * Uses `--hp-*` design tokens for full theme customisation.
+ * No `!important`, no position/top/left/transform overrides.
+ */
+
+@layer hp-styles {
+  /* --- Trigger area --- */
+  hp-context-menu-trigger {
+    color: var(--hp-text, CanvasText);
+    font-family: inherit;
+    font-size: var(--hp-font-size-sm, 0.875rem);
+    border-color: var(--hp-border-strong, color-mix(in srgb, currentColor 20%, transparent));
+    border-radius: var(--hp-radius, 0.375rem);
+    transition:
+      background-color var(--hp-transition, 150ms),
+      border-color var(--hp-transition, 150ms);
+  }
+
+  hp-context-menu-trigger:hover {
+    border-color: var(--hp-border, color-mix(in srgb, currentColor 30%, transparent));
+  }
+
+  hp-context-menu-trigger[data-state="open"] {
+    border-color: var(--hp-accent, currentColor);
+    background-color: var(--hp-bg-subtle, color-mix(in srgb, currentColor 14%, transparent));
+  }
+
+  /* --- Content panel --- */
+  hp-context-menu-content {
+    background-color: var(--hp-surface, Canvas);
+    color: var(--hp-text, CanvasText);
+    border-color: var(--hp-border, color-mix(in srgb, currentColor 25%, transparent));
+    border-radius: var(--hp-radius, 0.5rem);
+    box-shadow: var(--hp-shadow-lg, 0 8px 32px rgb(0 0 0 / 0.12), 0 2px 8px rgb(0 0 0 / 0.08));
+  }
+
+  /* --- Menu item --- */
+  hp-context-menu-item {
+    color: var(--hp-text, CanvasText);
+    font-size: var(--hp-font-size-sm, 0.875rem);
+    border-radius: var(--hp-radius-sm, 0.25rem);
+    margin-inline: var(--hp-space-1, 0.25rem);
+    padding: var(--hp-space-2, 0.5rem) var(--hp-space-3, 0.75rem);
+    transition:
+      background-color var(--hp-transition, 150ms),
+      color var(--hp-transition, 150ms);
+  }
+
+  hp-context-menu-item:hover:not([disabled]):not([aria-disabled="true"]) {
+    background-color: var(--hp-bg-muted, color-mix(in srgb, currentColor 8%, transparent));
+    color: var(--hp-text, CanvasText);
+  }
+
+  hp-context-menu-item:focus-visible {
+    outline: var(--hp-focus-outline-width, 2px) solid var(--hp-focus-outline-color, #2563eb);
+    outline-offset: -2px;
+  }
+
+  hp-context-menu-item[data-highlighted] {
+    background-color: var(--hp-bg-subtle, color-mix(in srgb, currentColor 14%, transparent));
+    color: var(--hp-accent, CanvasText);
+  }
+
+  hp-context-menu-item[disabled],
+  hp-context-menu-item[aria-disabled="true"] {
+    opacity: var(--hp-opacity-disabled, 0.45);
+    cursor: not-allowed;
+    pointer-events: none;
+  }
+
+  /* --- Separator --- */
+  hp-context-menu-separator {
+    background-color: var(--hp-border, color-mix(in srgb, currentColor 15%, transparent));
+    margin: var(--hp-space-1, 0.25rem) 0;
+  }
+
+  /* --- Label --- */
+  hp-context-menu-label {
+    padding: var(--hp-space-1, 0.25rem) var(--hp-space-3, 0.75rem);
+    font-size: var(--hp-font-size-xs, 0.75rem);
+    font-weight: var(--hp-font-weight-medium, 500);
+    color: var(--hp-text-secondary, color-mix(in srgb, currentColor 60%, transparent));
+  }
+
+  /* --- Reduced motion --- */
+  @media (prefers-reduced-motion: reduce) {
+    hp-context-menu-trigger,
+    hp-context-menu-content,
+    hp-context-menu-item {
+      transition: none;
+    }
+  }
+}

--- a/packages/vanilla/styles/src/index.css
+++ b/packages/vanilla/styles/src/index.css
@@ -25,6 +25,7 @@
 @import "./select.css";
 @import "./combobox.css";
 @import "./dropdown-menu.css";
+@import "./context-menu.css";
 @import "./atoms.css";
 @import "./badge.css";
 @import "./field.css";

--- a/packages/vanilla/utils/src/base.css
+++ b/packages/vanilla/utils/src/base.css
@@ -75,7 +75,13 @@ hp-dropdown-menu,
 hp-dropdown-menu-content,
 hp-dropdown-menu-item,
 hp-dropdown-menu-separator,
-hp-dropdown-menu-label {
+hp-dropdown-menu-label,
+hp-context-menu,
+hp-context-menu-trigger,
+hp-context-menu-content,
+hp-context-menu-item,
+hp-context-menu-separator,
+hp-context-menu-label {
   display: block;
 }
 
@@ -1015,6 +1021,124 @@ hp-dropdown-menu-separator {
 }
 
 hp-dropdown-menu-label {
+  padding: 0.375rem 0.75rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  opacity: 0.6;
+  user-select: none;
+}
+
+/* --- Context Menu --- */
+hp-context-menu {
+  position: relative;
+  box-sizing: border-box;
+}
+
+hp-context-menu-trigger {
+  display: block;
+  cursor: context-menu;
+}
+
+hp-context-menu-content {
+  position: absolute;
+  z-index: var(--hp-z-index-popover);
+  min-width: 8rem;
+  color-scheme: light dark;
+  background-color: var(--hp-surface, Canvas);
+  color: var(--hp-text, CanvasText);
+  border: 1px solid var(--hp-border, color-mix(in srgb, currentColor 25%, transparent));
+  border-radius: var(--hp-radius, 0.5rem);
+  box-shadow: var(--hp-shadow-lg, 0 8px 32px rgb(0 0 0 / 0.12), 0 2px 8px rgb(0 0 0 / 0.08));
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition:
+    opacity var(--hp-transition, 150ms) var(--hp-ease, ease),
+    visibility var(--hp-transition, 150ms) var(--hp-ease, ease);
+  max-height: 20rem;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+hp-context-menu-content[data-state="open"] {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+}
+
+hp-context-menu-content[data-state="closed"] {
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+}
+
+hp-context-menu-content::-webkit-scrollbar {
+  width: 8px;
+}
+
+hp-context-menu-content::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+hp-context-menu-content::-webkit-scrollbar-thumb {
+  background-color: var(--hp-border-strong, color-mix(in srgb, currentColor 25%, transparent));
+  border-radius: 4px;
+  border: 2px solid var(--hp-surface, Canvas);
+}
+
+hp-context-menu-content::-webkit-scrollbar-thumb:hover {
+  background-color: var(--hp-text-secondary, color-mix(in srgb, currentColor 40%, transparent));
+}
+
+hp-context-menu-item {
+  display: flex;
+  align-items: center;
+  gap: var(--hp-space-2);
+  width: 100%;
+  padding: var(--hp-space-2) var(--hp-space-4);
+  font-family: inherit;
+  font-size: var(--hp-font-size-sm);
+  color: var(--hp-text, CanvasText);
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  user-select: none;
+  text-align: left;
+  transition:
+    background-color var(--hp-transition, 150ms),
+    color var(--hp-transition, 150ms);
+  box-sizing: border-box;
+  min-height: 2rem;
+}
+
+hp-context-menu-item:hover:not([aria-disabled="true"]):not([disabled]) {
+  background-color: var(--hp-bg-muted, color-mix(in srgb, currentColor 8%, transparent));
+}
+
+hp-context-menu-item[data-highlighted] {
+  background-color: var(--hp-bg-subtle, color-mix(in srgb, currentColor 14%, transparent));
+}
+
+hp-context-menu-item[aria-disabled="true"],
+hp-context-menu-item[disabled] {
+  opacity: var(--hp-opacity-disabled);
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+hp-context-menu-item:focus-visible {
+  outline: var(--hp-focus-outline-width) solid var(--hp-focus-outline-color);
+  outline-offset: -2px;
+}
+
+hp-context-menu-separator {
+  height: 1px;
+  margin: 0.25rem 0;
+  background-color: currentColor;
+  opacity: 0.2;
+}
+
+hp-context-menu-label {
   padding: 0.375rem 0.75rem;
   font-size: 0.75rem;
   font-weight: 500;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       '@headless-primitives/combobox':
         specifier: workspace:*
         version: link:../../packages/vanilla/combobox
+      '@headless-primitives/context-menu':
+        specifier: workspace:*
+        version: link:../../packages/vanilla/context-menu
       '@headless-primitives/dialog':
         specifier: workspace:*
         version: link:../../packages/vanilla/dialog
@@ -147,6 +150,9 @@ importers:
       '@headless-primitives/combobox':
         specifier: workspace:*
         version: link:../../packages/vanilla/combobox
+      '@headless-primitives/context-menu':
+        specifier: workspace:*
+        version: link:../../packages/vanilla/context-menu
       '@headless-primitives/dialog':
         specifier: workspace:*
         version: link:../../packages/vanilla/dialog
@@ -287,6 +293,28 @@ importers:
       lit:
         specifier: ^3.3.2
         version: 3.3.2
+
+  packages/vanilla/context-menu:
+    dependencies:
+      '@headless-primitives/utils':
+        specifier: workspace:*
+        version: link:../utils
+      lit:
+        specifier: ^3.3.2
+        version: 3.3.2
+    devDependencies:
+      happy-dom:
+        specifier: ^14.12.3
+        version: 14.12.3
+      typescript:
+        specifier: ^5.4.0
+        version: 5.9.3
+      vite:
+        specifier: ^5.4.2
+        version: 5.4.21(@types/node@25.5.0)(lightningcss@1.32.0)
+      vitest:
+        specifier: ^2.0.5
+        version: 2.1.9(@types/node@25.5.0)(happy-dom@14.12.3)(jsdom@29.0.1)(lightningcss@1.32.0)
 
   packages/vanilla/dialog:
     dependencies:


### PR DESCRIPTION
Add hp-context-menu primitive with right-click trigger, cursor-position positioning, full WAI-ARIA Menu pattern, keyboard navigation (Shift+F10, arrows, Home/End, Enter/Space, Escape, Tab), and singleton behavior.

Includes 6 sub-components, 26 tests, playground demo, VitePress docs, base.css structural styles, @styles theming layer, and ThemeBuilder preview.