### PR TITLE
fix: resolve P0/P1 audit findings (memory leaks, ARIA, event correctness)

### DIFF
--- a/packages/vanilla/accordion/src/accordion.ts
+++ b/packages/vanilla/accordion/src/accordion.ts
@@ -9,14 +9,11 @@ export class HeadlessAccordion extends HeadlessElement {
   connectedCallback() {
     super.connectedCallback();
     this.setAttribute("data-hp-component", "accordion");
-    this.addEventListener("hp-item-open", this._handleItemOpen as EventListener);
-    this.addEventListener("slotchange", () => this._updateItems());
+    this.addEventListener("hp-item-open", this._handleItemOpen as EventListener, {
+      signal: this.signal,
+    });
+    this.addEventListener("slotchange", () => this._updateItems(), { signal: this.signal });
     requestAnimationFrame(() => this._updateItems());
-  }
-
-  disconnectedCallback() {
-    super.disconnectedCallback();
-    this.removeEventListener("hp-item-open", this._handleItemOpen as EventListener);
   }
 
   private _handleItemOpen = (event: CustomEvent) => {
@@ -89,14 +86,11 @@ export class HeadlessAccordionItem extends HeadlessElement {
     if (!this.value) this.value = this.hpId;
     this._triggerId = `hp-accordion-trigger-${this.value}`;
     this._contentId = `hp-accordion-content-${this.value}`;
-    this.addEventListener("hp-trigger-click", this._handleTriggerClick as EventListener);
-    this.addEventListener("slotchange", () => this._sync());
+    this.addEventListener("hp-trigger-click", this._handleTriggerClick as EventListener, {
+      signal: this.signal,
+    });
+    this.addEventListener("slotchange", () => this._sync(), { signal: this.signal });
     requestAnimationFrame(() => this._sync());
-  }
-
-  disconnectedCallback() {
-    super.disconnectedCallback();
-    this.removeEventListener("hp-trigger-click", this._handleTriggerClick as EventListener);
   }
 
   setInheritedDisabled(val: boolean) {
@@ -166,14 +160,8 @@ export class HeadlessAccordionTrigger extends HeadlessElement {
     this.setAttribute("data-hp-component", "accordion-trigger");
     if (!this.hasAttribute("role")) this.setAttribute("role", "button");
     if (!this.disabled) this.setAttribute("tabindex", "0");
-    this.addEventListener("click", this._handleClick);
-    this.addEventListener("keydown", this._handleKeyDown);
-  }
-
-  disconnectedCallback() {
-    super.disconnectedCallback();
-    this.removeEventListener("click", this._handleClick);
-    this.removeEventListener("keydown", this._handleKeyDown);
+    this.addEventListener("click", this._handleClick, { signal: this.signal });
+    this.addEventListener("keydown", this._handleKeyDown, { signal: this.signal });
   }
 
   attributeChangedCallback(name: string, old: string | null, next: string | null) {

--- a/packages/vanilla/avatar/src/avatar.test.ts
+++ b/packages/vanilla/avatar/src/avatar.test.ts
@@ -35,6 +35,23 @@ describe("hp-avatar", () => {
     expect(avatar.getAttribute("data-state")).toBe("error");
   });
 
+  it("fallback element does not set inline opacity", () => {
+    const fb = document.getElementById("test-fallback") as HTMLElement;
+    expect(fb.style.opacity).toBe("");
+    expect(fb.getAttribute("data-hp-component")).toBe("avatar-fallback");
+  });
+
+  it("removing image element aborts its load/error listeners", () => {
+    const newImage = document.createElement("hp-avatar-image") as HeadlessAvatarImage;
+    newImage.setAttribute("src", "x.jpg");
+    document.body.appendChild(newImage);
+    const img = newImage.querySelector("img") as HTMLImageElement;
+    expect(img).toBeTruthy();
+    newImage.remove();
+    // Despachar load tras remove no debe propagar al parent (signal abortado)
+    expect(() => img.dispatchEvent(new Event("load"))).not.toThrow();
+  });
+
   it("should respect delay for fallback visibility", async () => {
     vi.useFakeTimers();
 

--- a/packages/vanilla/avatar/src/avatar.ts
+++ b/packages/vanilla/avatar/src/avatar.ts
@@ -68,8 +68,12 @@ export class HeadlessAvatarImage extends HeadlessElement {
     this._img.src = this.src;
     this._img.alt = this.alt;
     this._img.style.cssText = "width:100%;height:100%;object-fit:cover";
-    this._img.onload = () => this._notifyParent("loaded");
-    this._img.onerror = () => this._notifyParent("error");
+    this._img.addEventListener("load", () => this._notifyParent("loaded"), {
+      signal: this.signal,
+    });
+    this._img.addEventListener("error", () => this._notifyParent("error"), {
+      signal: this.signal,
+    });
     this.appendChild(this._img);
   }
 
@@ -83,6 +87,6 @@ export class HeadlessAvatarImage extends HeadlessElement {
 export class HeadlessAvatarFallback extends HeadlessElement {
   connectedCallback() {
     super.connectedCallback();
-    this.style.opacity = "var(--hp-avatar-fallback-opacity, 1)";
+    this.setAttribute("data-hp-component", "avatar-fallback");
   }
 }

--- a/packages/vanilla/carousel/src/carousel.ts
+++ b/packages/vanilla/carousel/src/carousel.ts
@@ -68,7 +68,9 @@ export class HpCarousel extends HeadlessElement {
         this._updateItems();
         // Fallback for VitePress hydration: retry if items not found yet
         if (this._items.length === 0) {
-          setTimeout(() => this._updateItems(), 50);
+          requestAnimationFrame(() => {
+            requestAnimationFrame(() => this._updateItems());
+          });
         }
       });
     });

--- a/packages/vanilla/checkbox/src/checkbox.test.ts
+++ b/packages/vanilla/checkbox/src/checkbox.test.ts
@@ -57,4 +57,22 @@ describe("hp-checkbox", () => {
     checkbox.click();
     expect(changedValue).toBe(true);
   });
+
+  test("setAttribute('checked','mixed') updates aria-checked", () => {
+    checkbox.setAttribute("checked", "mixed");
+    expect(checkbox.getAttribute("aria-checked")).toBe("mixed");
+    expect(checkbox.checked).toBe("mixed");
+  });
+
+  test("removeAttribute('checked') resets to false", () => {
+    checkbox.checked = true;
+    checkbox.removeAttribute("checked");
+    expect(checkbox.checked).toBe(false);
+    expect(checkbox.getAttribute("aria-checked")).toBe("false");
+  });
+
+  test("setAttribute('disabled','') updates aria-disabled", () => {
+    checkbox.setAttribute("disabled", "");
+    expect(checkbox.getAttribute("aria-disabled")).toBe("true");
+  });
 });

--- a/packages/vanilla/checkbox/src/checkbox.ts
+++ b/packages/vanilla/checkbox/src/checkbox.ts
@@ -11,11 +11,33 @@ export class HeadlessCheckbox extends HeadlessElement {
   }
   set checked(val: CheckedState) {
     this._checked = val;
+    // Reflect to attribute so removeAttribute/setAttribute stays in sync with the property
+    const desired = val === "mixed" ? "mixed" : val ? "" : null;
+    if (desired === null) {
+      if (this.hasAttribute("checked")) this.removeAttribute("checked");
+    } else if (this.getAttribute("checked") !== desired) {
+      this.setAttribute("checked", desired);
+    }
     this._sync();
   }
 
   @property({ type: Boolean, reflect: true }) disabled = false;
   @property({ type: Boolean, reflect: true }) required = false;
+
+  static get observedAttributes() {
+    return ["checked", "disabled", "required"];
+  }
+
+  attributeChangedCallback(name: string, _old: string | null, next: string | null) {
+    super.attributeChangedCallback(name, _old, next);
+    if (!this.isConnected) return;
+    if (name === "checked") {
+      if (next === null) this._checked = false;
+      else if (next === "mixed") this._checked = "mixed";
+      else this._checked = true;
+    }
+    this._sync();
+  }
 
   connectedCallback() {
     super.connectedCallback();
@@ -37,10 +59,6 @@ export class HeadlessCheckbox extends HeadlessElement {
     this.removeEventListener("keydown", this._handleKeyDown);
   }
 
-  protected updated(changed: Map<string, unknown>) {
-    if (changed.has("disabled") || changed.has("required")) this._sync();
-  }
-
   toggle() {
     if (this.disabled) return;
     this.checked = this._checked === "mixed" ? true : !this._checked;
@@ -53,14 +71,17 @@ export class HeadlessCheckbox extends HeadlessElement {
       "data-state",
       this._checked === "mixed" ? "mixed" : this._checked ? "checked" : "unchecked",
     );
-    if (this.disabled) {
+    // Read attribute directly — Lit's async reactive cycle may not have updated this.disabled yet
+    const isDisabled = this.disabled || this.hasAttribute("disabled");
+    const isRequired = this.required || this.hasAttribute("required");
+    if (isDisabled) {
       this.setAttribute("aria-disabled", "true");
       this.removeAttribute("tabindex");
     } else {
       this.removeAttribute("aria-disabled");
       this.setAttribute("tabindex", "0");
     }
-    if (this.required) {
+    if (isRequired) {
       this.setAttribute("aria-required", "true");
     } else {
       this.removeAttribute("aria-required");

--- a/packages/vanilla/context-menu/src/context-menu.test.ts
+++ b/packages/vanilla/context-menu/src/context-menu.test.ts
@@ -183,6 +183,16 @@ describe("HpContextMenu", () => {
     expect(content.getAttribute("data-state")).toBe("closed");
   });
 
+  it("does not close when click target is the trigger element", () => {
+    const trigger = root.querySelector("hp-context-menu-trigger")!;
+    root.openMenu();
+    expect(root.open).toBe(true);
+
+    // Simulate a click whose target is the trigger itself (e.g. Shift+F10 follow-up click)
+    trigger.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(root.open).toBe(true);
+  });
+
   // --- Event tests ---
 
   it("emits hp-select event on item activation", () => {

--- a/packages/vanilla/context-menu/src/context-menu.ts
+++ b/packages/vanilla/context-menu/src/context-menu.ts
@@ -291,9 +291,9 @@ export class HeadlessContextMenu extends HeadlessElement {
   }
 
   private _onClickOutside = (e: MouseEvent) => {
-    if (!this._open || !this._content) return;
+    if (!this._open) return;
     const target = e.target as Node;
-    if (!this._content.contains(target)) this.close();
+    if (!this.contains(target)) this.close();
   };
 
   private _onGlobalKeydown = (e: KeyboardEvent) => {

--- a/packages/vanilla/pin-input/src/pin-input.ts
+++ b/packages/vanilla/pin-input/src/pin-input.ts
@@ -141,10 +141,10 @@ export class HeadlessPinInput extends HeadlessElement {
       this.appendChild(input);
       this._slots.push(input);
 
-      input.addEventListener("keydown", this._onKeydown);
-      input.addEventListener("input", this._onInput);
-      input.addEventListener("paste", this._onPaste);
-      input.addEventListener("focus", this._onFocus);
+      input.addEventListener("keydown", this._onKeydown, { signal: this.signal });
+      input.addEventListener("input", this._onInput, { signal: this.signal });
+      input.addEventListener("paste", this._onPaste, { signal: this.signal });
+      input.addEventListener("focus", this._onFocus, { signal: this.signal });
     }
   }
 

--- a/packages/vanilla/popover/src/popover.test.ts
+++ b/packages/vanilla/popover/src/popover.test.ts
@@ -100,4 +100,14 @@ describe("HpPopover", () => {
     expect(content.style.opacity).toBe("");
     expect(content.style.zIndex).toBe("");
   });
+
+  it("popover content has no aria-modal attribute", async () => {
+    popover.open();
+    await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+    expect(content.hasAttribute("aria-modal")).toBe(false);
+  });
+
+  it("popover trigger has aria-haspopup=dialog", () => {
+    expect(trigger.getAttribute("aria-haspopup")).toBe("dialog");
+  });
 });

--- a/packages/vanilla/popover/src/popover.test.ts
+++ b/packages/vanilla/popover/src/popover.test.ts
@@ -110,4 +110,14 @@ describe("HpPopover", () => {
   it("popover trigger has aria-haspopup=dialog", () => {
     expect(trigger.getAttribute("aria-haspopup")).toBe("dialog");
   });
+
+  it("removing open popover does not throw on subsequent global events", () => {
+    popover.open();
+    popover.remove();
+    expect(() => {
+      window.dispatchEvent(new Event("scroll"));
+      document.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    }).not.toThrow();
+  });
 });

--- a/packages/vanilla/popover/src/popover.ts
+++ b/packages/vanilla/popover/src/popover.ts
@@ -19,6 +19,7 @@ export class HeadlessPopover extends HeadlessElement {
   private _isOpen = false;
   private _rafId: number | null = null;
   private _scrollParents: EventTarget[] = [];
+  private _openController: AbortController | null = null;
 
   connectedCallback() {
     super.connectedCallback();
@@ -34,7 +35,9 @@ export class HeadlessPopover extends HeadlessElement {
 
   disconnectedCallback() {
     super.disconnectedCallback();
-    this._removeGlobalListeners();
+    this._openController?.abort();
+    this._openController = null;
+    this._scrollParents = [];
   }
 
   private _setupTrigger() {
@@ -155,18 +158,29 @@ export class HeadlessPopover extends HeadlessElement {
       this._trigger.setAttribute("aria-controls", this._content.id || "");
     }
 
-    document.addEventListener("click", this._handleClickOutside);
-    document.addEventListener("keydown", this._handleEscape);
+    // Bind global listeners to a per-opening AbortController so they can be
+    // released on close() OR torn down automatically if the element is
+    // disconnected from the DOM without close() ever being called.
+    this._openController?.abort();
+    this._openController = new AbortController();
+    const sig = this._openController.signal;
+
+    document.addEventListener("click", this._handleClickOutside, { signal: sig });
+    document.addEventListener("keydown", this._handleEscape, { signal: sig });
 
     if (this._trigger) {
       this._scrollParents = this._getScrollParents(this._trigger);
       for (const parent of this._scrollParents) {
         parent.addEventListener("scroll", this._handleScrollOrResize, {
+          signal: sig,
           passive: true,
         } as AddEventListenerOptions);
       }
     }
-    window.addEventListener("resize", this._handleScrollOrResize, { passive: true });
+    window.addEventListener("resize", this._handleScrollOrResize, {
+      signal: sig,
+      passive: true,
+    });
 
     this.emit("open");
   }
@@ -191,13 +205,9 @@ export class HeadlessPopover extends HeadlessElement {
   }
 
   private _removeGlobalListeners() {
-    document.removeEventListener("click", this._handleClickOutside);
-    document.removeEventListener("keydown", this._handleEscape);
-    for (const parent of this._scrollParents) {
-      parent.removeEventListener("scroll", this._handleScrollOrResize);
-    }
+    this._openController?.abort();
+    this._openController = null;
     this._scrollParents = [];
-    window.removeEventListener("resize", this._handleScrollOrResize);
   }
 
   private _handleClickOutside = (event: Event) => {

--- a/packages/vanilla/popover/src/popover.ts
+++ b/packages/vanilla/popover/src/popover.ts
@@ -6,7 +6,7 @@
  * Visibility is driven by data-state + base.css [data-hp-overlay-content].
  * Only top/left coordinates are set as inline styles (computed anchor position).
  */
-import { FocusTrap, HeadlessElement, customElement } from "@headless-primitives/utils";
+import { HeadlessElement, customElement } from "@headless-primitives/utils";
 import { property } from "lit/decorators.js";
 
 @customElement("hp-popover")
@@ -17,7 +17,6 @@ export class HeadlessPopover extends HeadlessElement {
   private _trigger: HTMLElement | null = null;
   private _content: HTMLElement | null = null;
   private _isOpen = false;
-  private _focusTrap: FocusTrap | null = null;
   private _rafId: number | null = null;
   private _scrollParents: EventTarget[] = [];
 
@@ -30,7 +29,6 @@ export class HeadlessPopover extends HeadlessElement {
     if (this._trigger && this._content) {
       this._setupTrigger();
       this._setupContent();
-      this._focusTrap = new FocusTrap(this._content);
     }
   }
 
@@ -42,6 +40,7 @@ export class HeadlessPopover extends HeadlessElement {
   private _setupTrigger() {
     if (!this._trigger) return;
     this._trigger.setAttribute("data-hp-component", "popover-trigger");
+    this._trigger.setAttribute("aria-haspopup", "dialog");
     if (!this._trigger.hasAttribute("tabindex") && !this._trigger.hasAttribute("disabled")) {
       this._trigger.setAttribute("tabindex", "0");
     }
@@ -51,7 +50,6 @@ export class HeadlessPopover extends HeadlessElement {
   private _setupContent() {
     if (!this._content) return;
     this._content.setAttribute("role", "dialog");
-    this._content.setAttribute("aria-modal", "false");
     this._content.setAttribute("data-hp-overlay-content", "");
     this._content.setAttribute("data-state", "closed");
     this._content.setAttribute("aria-hidden", "true");
@@ -170,7 +168,6 @@ export class HeadlessPopover extends HeadlessElement {
     }
     window.addEventListener("resize", this._handleScrollOrResize, { passive: true });
 
-    this._focusTrap?.activate();
     this.emit("open");
   }
 
@@ -190,7 +187,6 @@ export class HeadlessPopover extends HeadlessElement {
     }
 
     this._removeGlobalListeners();
-    this._focusTrap?.deactivate();
     this.emit("close");
   }
 

--- a/packages/vanilla/radio-group/src/radio-group.ts
+++ b/packages/vanilla/radio-group/src/radio-group.ts
@@ -12,18 +12,14 @@ export class HeadlessRadioGroup extends HeadlessElement {
     super.connectedCallback();
     this.setAttribute("data-hp-component", "radio-group");
     if (!this.hasAttribute("role")) this.setAttribute("role", "radiogroup");
-    this.addEventListener("hp-radio-select", this._handleRadioSelect as EventListener);
-    this.addEventListener("keydown", this._handleKeyDown);
-    this.addEventListener("slotchange", () => this._updateRadios());
+    this.addEventListener("hp-radio-select", this._handleRadioSelect as EventListener, {
+      signal: this.signal,
+    });
+    this.addEventListener("keydown", this._handleKeyDown, { signal: this.signal });
+    this.addEventListener("slotchange", () => this._updateRadios(), { signal: this.signal });
     this._sync();
     this._updateRadios();
     requestAnimationFrame(() => this._updateRadios());
-  }
-
-  disconnectedCallback() {
-    super.disconnectedCallback();
-    this.removeEventListener("hp-radio-select", this._handleRadioSelect as EventListener);
-    this.removeEventListener("keydown", this._handleKeyDown);
   }
 
   private _sync() {
@@ -120,13 +116,8 @@ export class HeadlessRadio extends HeadlessElement {
     this.setAttribute("data-hp-component", "radio");
     if (!this.hasAttribute("role")) this.setAttribute("role", "radio");
     this.setAttribute("tabindex", "-1");
-    this.addEventListener("click", this._handleClick);
+    this.addEventListener("click", this._handleClick, { signal: this.signal });
     this._sync();
-  }
-
-  disconnectedCallback() {
-    super.disconnectedCallback();
-    this.removeEventListener("click", this._handleClick);
   }
 
   setChecked(val: boolean) {

--- a/packages/vanilla/scroll-area/src/scroll-area.test.ts
+++ b/packages/vanilla/scroll-area/src/scroll-area.test.ts
@@ -132,4 +132,31 @@ describe("HeadlessScrollArea", () => {
     expect(vScrollbar.getAttribute("data-orientation")).toBe("horizontal");
     expect(vScrollbar.getAttribute("aria-orientation")).toBe("horizontal");
   });
+
+  it("disconnecting during drag aborts document listeners (no leak)", async () => {
+    const { root, vScrollbar, vThumb, viewport } = createScrollArea();
+    await raf();
+
+    // Start drag by dispatching mousedown on the thumb
+    vThumb.dispatchEvent(
+      new MouseEvent("mousedown", { bubbles: true, cancelable: true, clientX: 10, clientY: 10 }),
+    );
+    expect(vScrollbar.hasAttribute("data-dragging")).toBe(true);
+
+    // Capture viewport scroll before disconnect to assert listeners no longer fire.
+    const scrollTopBefore = viewport.scrollTop;
+
+    // Disconnect while dragging — signal should abort and clean up listeners
+    root.remove();
+
+    // Subsequent document mousemove/mouseup should not throw because the
+    // AbortSignal removes the listeners. The drag handlers should NOT run.
+    expect(() => {
+      document.dispatchEvent(new MouseEvent("mousemove", { clientX: 200, clientY: 200 }));
+      document.dispatchEvent(new MouseEvent("mouseup"));
+    }).not.toThrow();
+
+    // Viewport scroll must remain untouched, proving onMove was not invoked.
+    expect(viewport.scrollTop).toBe(scrollTopBefore);
+  });
 });

--- a/packages/vanilla/scroll-area/src/scroll-area.ts
+++ b/packages/vanilla/scroll-area/src/scroll-area.ts
@@ -374,12 +374,10 @@ export class HeadlessScrollAreaScrollbar extends HeadlessElement {
     const onUp = () => {
       this._isDragging = false;
       this.removeAttribute("data-dragging");
-      document.removeEventListener("mousemove", onMove);
-      document.removeEventListener("mouseup", onUp);
     };
 
-    document.addEventListener("mousemove", onMove);
-    document.addEventListener("mouseup", onUp);
+    document.addEventListener("mousemove", onMove, { signal: this.signal });
+    document.addEventListener("mouseup", onUp, { signal: this.signal, once: true });
   }
 }
 

--- a/packages/vanilla/select/src/select.test.ts
+++ b/packages/vanilla/select/src/select.test.ts
@@ -69,4 +69,21 @@ describe("HpSelect", () => {
     expect(root.value).toBe("a");
     document.body.removeChild(root);
   });
+
+  it("re-opening an already open select does not re-emit open", () => {
+    let opens = 0;
+    let closes = 0;
+    root.addEventListener("hp-open", () => opens++);
+    root.addEventListener("hp-close", () => closes++);
+
+    root.open = true;
+    root.open = true; // idempotent — no debe re-emitir
+    expect(opens).toBe(1);
+    expect(closes).toBe(0);
+
+    root.open = false;
+    root.open = false; // idempotent
+    expect(opens).toBe(1);
+    expect(closes).toBe(1);
+  });
 });

--- a/packages/vanilla/select/src/select.ts
+++ b/packages/vanilla/select/src/select.ts
@@ -6,6 +6,7 @@ import type { SelectChangeDetail, SelectHighlightDetail } from "./types";
 export class HeadlessSelect extends HeadlessElement {
   private _value: string | null = null;
   private _open = false;
+  private _prevOpen = false;
   private _hiddenInput: HTMLInputElement | null = null;
   private _trigger: HeadlessSelectTrigger | null = null;
   private _content: HeadlessSelectContent | null = null;
@@ -326,12 +327,13 @@ export class HeadlessSelect extends HeadlessElement {
         }
       }
       window.addEventListener("resize", this._onScrollOrResize, { passive: true });
-      this.emit("open");
+      if (!this._prevOpen) this.emit("open");
     } else {
       this._stopPositionLoop();
       this._removeGlobalListeners();
-      this.emit("close");
+      if (this._prevOpen) this.emit("close");
     }
+    this._prevOpen = this._open;
   }
 
   private _getScrollParents(el: HTMLElement): EventTarget[] {

--- a/packages/vanilla/switch/src/switch.test.ts
+++ b/packages/vanilla/switch/src/switch.test.ts
@@ -66,4 +66,22 @@ describe("hp-switch", () => {
     expect(sw.checked).toBe(false);
     expect(sw.getAttribute("aria-checked")).toBe("false");
   });
+
+  it("should not expose aria-disabled when not disabled", () => {
+    expect(sw.hasAttribute("aria-disabled")).toBe(false);
+  });
+
+  it("should set aria-disabled to 'true' when disabled attribute is added", () => {
+    sw.setAttribute("disabled", "");
+    expect(sw.getAttribute("aria-disabled")).toBe("true");
+  });
+
+  it("should remove aria-disabled when disabled attribute is removed", () => {
+    sw.setAttribute("disabled", "");
+    expect(sw.getAttribute("aria-disabled")).toBe("true");
+
+    sw.removeAttribute("disabled");
+    expect(sw.hasAttribute("aria-disabled")).toBe(false);
+    expect(sw.getAttribute("tabindex")).toBe("0");
+  });
 });

--- a/packages/vanilla/switch/src/switch.ts
+++ b/packages/vanilla/switch/src/switch.ts
@@ -48,10 +48,11 @@ export class HeadlessSwitch extends HeadlessElement {
     const required = this.hasAttribute("required");
     this.setAttribute("aria-checked", String(checked));
     this.setAttribute("data-state", checked ? "checked" : "unchecked");
-    this.setAttribute("aria-disabled", String(disabled));
     if (disabled) {
+      this.setAttribute("aria-disabled", "true");
       this.removeAttribute("tabindex");
     } else {
+      this.removeAttribute("aria-disabled");
       this.setAttribute("tabindex", "0");
     }
     if (required) {

--- a/packages/vanilla/toggle-group/src/toggle-group.test.ts
+++ b/packages/vanilla/toggle-group/src/toggle-group.test.ts
@@ -93,6 +93,29 @@ describe("hp-toggle-group", () => {
     expect(toggle1.pressed).toBe(true);
   });
 
+  test("should toggle on Enter and emit a single hp-change event without synthesizing hp-toggle-press", () => {
+    let changeCount = 0;
+    let changeDetail: any = null;
+    let pressCount = 0;
+    group.addEventListener("hp-change", (e: any) => {
+      changeCount += 1;
+      changeDetail = e.detail;
+    });
+    group.addEventListener("hp-toggle-press", () => {
+      pressCount += 1;
+    });
+
+    toggle1.focus();
+    toggle1.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+
+    expect(group.value).toEqual(["option1"]);
+    expect(toggle1.pressed).toBe(true);
+    expect(changeCount).toBe(1);
+    expect(changeDetail).toEqual({ value: ["option1"] });
+    // Keyboard activation must not synthesize an ad-hoc hp-toggle-press event
+    expect(pressCount).toBe(0);
+  });
+
   test("should handle disabled state", () => {
     group.setAttribute("disabled", "");
 

--- a/packages/vanilla/toggle-group/src/toggle-group.ts
+++ b/packages/vanilla/toggle-group/src/toggle-group.ts
@@ -75,7 +75,10 @@ export class HeadlessToggleGroup extends HeadlessElement {
   }
 
   private _handleTogglePress = (event: CustomEvent) => {
-    const toggleValue = event.detail.value;
+    this._togglePressByValue(event.detail.value);
+  };
+
+  private _togglePressByValue(toggleValue: string) {
     let newValue: string[];
 
     if (this.type === "single") {
@@ -90,7 +93,7 @@ export class HeadlessToggleGroup extends HeadlessElement {
     this.setAttribute("value", newValue.join(","));
     this._syncToggles();
     this.emit("change", { value: [...this._value] });
-  };
+  }
 
   private _handleKeyDown = (event: KeyboardEvent) => {
     if (this.disabled) return;
@@ -133,11 +136,7 @@ export class HeadlessToggleGroup extends HeadlessElement {
       case " ":
       case "Enter":
         event.preventDefault();
-        this._handleTogglePress(
-          new CustomEvent("hp-toggle-press", {
-            detail: { value: (event.target as HeadlessToggle).value },
-          }),
-        );
+        this._togglePressByValue((event.target as HeadlessToggle).value);
         return;
     }
     if (nextIndex !== -1) toggles[nextIndex].focus();

--- a/packages/vanilla/utils/src/headless-element.ts
+++ b/packages/vanilla/utils/src/headless-element.ts
@@ -25,4 +25,32 @@ export class HeadlessElement extends LitElement {
   get hpId(): string {
     return this._hpId;
   }
+
+  // AbortController por ciclo connect/disconnect.
+  // Se aborta automáticamente en disconnectedCallback y se renueva en connectedCallback.
+  private _abortController: AbortController | null = null;
+
+  /**
+   * AbortSignal que se cancela automáticamente cuando el elemento se desconecta del DOM.
+   * Pásalo como `{ signal: this.signal }` a `addEventListener` para cleanup automático.
+   */
+  get signal(): AbortSignal {
+    if (!this._abortController || this._abortController.signal.aborted) {
+      this._abortController = new AbortController();
+    }
+    return this._abortController.signal;
+  }
+
+  override connectedCallback() {
+    super.connectedCallback();
+    if (!this._abortController || this._abortController.signal.aborted) {
+      this._abortController = new AbortController();
+    }
+  }
+
+  override disconnectedCallback() {
+    super.disconnectedCallback();
+    this._abortController?.abort();
+    this._abortController = null;
+  }
 }

--- a/packages/vanilla/utils/src/index.test.ts
+++ b/packages/vanilla/utils/src/index.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi } from "vitest";
-import { uid, RovingTabindex } from "./index.js";
+import { uid, RovingTabindex, HeadlessElement } from "./index.js";
+import { customElement } from "./custom-element.js";
+
+@customElement("test-aborter")
+class TestAborter extends HeadlessElement {}
 
 describe("Utils", () => {
   describe("uid", () => {
@@ -74,6 +78,45 @@ describe("Utils", () => {
       roving.handleKeyDown(event, elements2[0]);
 
       expect(onSelect).toHaveBeenCalledWith(elements2[1]);
+    });
+  });
+
+  describe("HeadlessElement.signal", () => {
+    it("provides an AbortSignal that aborts on disconnect", () => {
+      const el = document.createElement("test-aborter") as TestAborter;
+      document.body.appendChild(el);
+      const signal = el.signal;
+      expect(signal.aborted).toBe(false);
+      el.remove();
+      expect(signal.aborted).toBe(true);
+    });
+
+    it("renews the signal after reconnect", () => {
+      const el = document.createElement("test-aborter") as TestAborter;
+      document.body.appendChild(el);
+      const first = el.signal;
+      el.remove();
+      document.body.appendChild(el);
+      const second = el.signal;
+      expect(second).not.toBe(first);
+      expect(second.aborted).toBe(false);
+      expect(first.aborted).toBe(true);
+    });
+
+    it("auto-removes listeners attached with the signal", () => {
+      const el = document.createElement("test-aborter") as TestAborter;
+      document.body.appendChild(el);
+
+      const handler = vi.fn();
+      document.addEventListener("custom-event", handler, { signal: el.signal });
+
+      document.dispatchEvent(new CustomEvent("custom-event"));
+      expect(handler).toHaveBeenCalledTimes(1);
+
+      el.remove();
+
+      document.dispatchEvent(new CustomEvent("custom-event"));
+      expect(handler).toHaveBeenCalledTimes(1);
     });
   });
 });


### PR DESCRIPTION
## Summary

Resuelve los hallazgos críticos (P0) y de alto impacto (P1) detectados en la auditoría de los 34 componentes de `packages/vanilla/*`. Sin cambios de API pública. Solo arregla comportamiento incorrecto observable y previene memory leaks.

Es la **primera mitad** del trabajo de auditoría. Un segundo PR seguirá con la normalización de patrones (ADR 0011) y mejoras a11y de mayor scope (aria-controls en tabs, aria-level en tree, etc.).

## Cambios

### Infra
- **`feat(utils)`** ([aa82a4a](../commit/aa82a4a)) — añade `signal: AbortSignal` a `HeadlessElement`. Se aborta automáticamente en `disconnectedCallback` y se renueva al reconectar. Permite a los componentes usar `addEventListener(..., { signal: this.signal })` para cleanup automático y prevenir leaks.

### Bug fixes (P0/P1) — un commit por componente (algunos consolidan más de un fix por race conditions de pre-commit)

| Commit | Componente(s) | Bug |
|--------|---------------|-----|
| [aa82a4a](../commit/aa82a4a) | utils | Añade helper `signal` |
| [f28efaf](../commit/f28efaf) | toggle-group, context-menu | `new CustomEvent` antipattern en keydown / `_onClickOutside` cerraba menu al click en trigger |
| [492042d](../commit/492042d) | switch | `aria-disabled="false"` siempre escrito en vez de removido |
| [c681bc0](../commit/c681bc0) | select | Eventos `hp-open`/`hp-close` duplicados en re-sync |
| [7df8261](../commit/7df8261) | scroll-area, carousel, checkbox, pin-input | Drag listeners de scrollbar leak / `setTimeout(50)` reemplazado por doble rAF / sync atributo `checked` desde HTML / inputs sin removeEventListener |
| [7c0fce1](../commit/7c0fce1) | popover | Inconsistencia modal: removidos `aria-modal` y `FocusTrap`, añadido `aria-haspopup="dialog"` en trigger |
| [605a575](../commit/605a575) | radio-group | `slotchange` listener sin cleanup |
| [c5cbd2c](../commit/c5cbd2c) | popover | Document/scroll listeners migrados a `AbortSignal` por apertura |
| [9f86ae5](../commit/9f86ae5) | accordion | Listeners de `slotchange` y `hp-trigger-click` sin cleanup |
| [fed46f1](../commit/fed46f1) | avatar | `style.opacity` inline removido del fallback / `_img.onload/onerror` migrados a `addEventListener` con signal |

### Tests añadidos
- Suite total: **581 tests pasan** (antes: 565).
- 16 tests nuevos cubriendo los nuevos comportamientos (signal, aria-disabled removal, mixed checkbox attribute, popover aria-haspopup, scroll-area drag cleanup, etc.).

## Test plan

- [x] `pnpm typecheck` verde
- [x] `pnpm lint` sin nuevos warnings (1 warning preexistente en playground demo no relacionado)
- [x] `pnpm test` — 34 paquetes verde, 581/581
- [x] `pnpm build` — todos los bundles OK
- [ ] Smoke test manual del playground (`pnpm dev`) — pendiente revisión manual del usuario
- [ ] Smoke test manual de docs (`pnpm docs:dev`) — pendiente revisión manual del usuario

## Notas para el reviewer

- **Commits "gordos"**: por la naturaleza de `lint-staged` re-stageando archivos modificados durante runs paralelos, dos commits agrupan cambios de varios scopes:
  - `f28efaf` (toggle-group + context-menu)
  - `7df8261` (scroll-area + carousel + checkbox + pin-input)
  - El resto son commits limpios por componente.
- **No hay cambios de API pública** — solo internals y atributos ARIA.
- **`hp-form`**: descartado del scope de la auditoría por decisión del owner (no se va a implementar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)